### PR TITLE
feat: cron job separation

### DIFF
--- a/worklenz-backend/README.md
+++ b/worklenz-backend/README.md
@@ -66,6 +66,31 @@
 
    This starts the production server for your application.
 
+7. **Run the Cron Server:**
+
+   **a. Compile TypeScript to JavaScript:**
+
+   Open a new terminal window and run the following command:
+
+      ```bash
+      grunt build
+      ```
+
+   This starts the `grunt` task runner, which compiles TypeScript code into JavaScript for production use.
+
+   **b. Start the cron server:**
+
+   Once the compilation is complete, run the following command in the same terminal window:
+
+      ```bash
+      npm run cron
+      ```
+
+   This starts the cron server for your application.
+
+   > It is not possible to run both an HTTP server and a Cron server on the same port simultaneously. 
+   > Therefore, you should run only one server at a time.
+
 ### CLI
 
 - Create controller: `$ node new controller Test`

--- a/worklenz-backend/package.json
+++ b/worklenz-backend/package.json
@@ -20,7 +20,8 @@
     "sonar": "sonar-scanner -Dproject.settings=sonar-project-dev.properties",
     "tsc": "tsc",
     "test": "jest --setupFiles dotenv/config",
-    "test:watch": "jest --watch --setupFiles dotenv/config"
+    "test:watch": "jest --watch --setupFiles dotenv/config",
+    "cron": "node ./build/bin/cron"
   },
   "jestSonar": {
     "reportPath": "coverage",

--- a/worklenz-backend/src/bin/cron.ts
+++ b/worklenz-backend/src/bin/cron.ts
@@ -4,6 +4,7 @@
 import "./config";
 import http, {IncomingHttpHeaders} from "http";
 import app from "../app";
+import {startCronJobs} from "../cron_jobs";
 import FileConstants from "../shared/file-constants";
 import DbTaskStatusChangeListener from "../pg_notify_listeners/db-task-status-changed";
 
@@ -52,8 +53,7 @@ function onListening() {
   const bind = typeof addr === "string"
     ? `pipe ${addr}`
     : `port ${addr.port}`;
-  // TODO - uncomment initRedis()
-  // void initRedis();
+  startCronJobs();
   FileConstants.init();
   void DbTaskStatusChangeListener.connect();
 


### PR DESCRIPTION
This pull request involves relocating the cron job from the www.ts  file to a separate server. The key changes and reasons for this modification are outlined below:

Changes Made:
- startCronJobs() function removed from www.ts
- startCronJobs() moved to new server as cron.ts
- Cron server start command added to the package.json
- Instruction added to the documentation   

Reasons for the change:
- By offloading the cron job to a separate server, we can reduce the load on the main application server, enhancing its performance and responsiveness.
- Running the cron job on a dedicated server minimizes the risk of it being affected by the main server's workload or potential downtimes.
- This change allows for easier scaling of both the main application and the cron job independently, improving overall system scalability.
- Separating concerns between the main application logic and scheduled tasks simplifies maintenance and future updates.