### PR TITLE
Add workflow to pre-build docker images

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,50 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+      - 'main'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        service:
+          - name: frontend
+            context: ./worklenz-frontend
+            container_name: worklenz_frontend
+          - name: backend
+            context: ./worklenz-backend
+            container_name: worklenz_backend
+    steps:
+      - name: Checkout the codebase
+        uses: actions/checkout@v4
+
+      - name: Login to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service.container_name }}
+          flavor: |
+            latest=true     
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.service.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   frontend:
+    image: ghcr.io/worklenz/worklenz-frontend
     build:
       context: ./worklenz-frontend
       dockerfile: Dockerfile
@@ -11,6 +12,7 @@ services:
         condition: service_started
 
   backend:
+    image: ghcr.io/worklenz/worklenz-frontend
     build:
       context: ./worklenz-backend
       dockerfile: Dockerfile


### PR DESCRIPTION
This PR adds a workflow file, which builds both the frontend and the backend and publishes the image to the ghcr.io package library. 

You can see a sample run here:
https://github.com/TheZoker/worklenz/actions/runs/9341503337

And the prebuild images here:
https://github.com/TheZoker/worklenz/pkgs/container/worklenz_frontend
https://github.com/TheZoker/worklenz/pkgs/container/worklenz_backend

Docs can be found here:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images

This closes #28 