### PR TITLE
[PR] Resized the sizes of final images for frontend and backend below 150MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
 .vscode
 
-
+node_modules/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       dockerfile: Dockerfile
     container_name: worklenz_frontend
     ports:
-      - "4200:4200"
+      - "80:80"
+      - "44:443"
     depends_on:
       backend:
         condition: service_started

--- a/worklenz-backend/Dockerfile
+++ b/worklenz-backend/Dockerfile
@@ -1,5 +1,7 @@
-# Use the official Node.js 18 image as a base
-FROM node:18
+# FIRST STAGE: Install Dependencies
+
+# Use the official Node.js 18-alpine3.20 image as a base
+FROM node:18-alpine3.20 as base
 
 # Create and set the working directory
 WORKDIR /usr/src/app
@@ -18,6 +20,15 @@ COPY . .
 
 # Run the build script to compile TypeScript to JavaScript
 RUN npm run build
+
+# SECOND STAGE: RUN THE APPLICATION
+
+
+FROM node:18-alpine3.20 as prod
+
+WORKDIR /usr/src/app
+
+COPY --from=base /usr/src/app .
 
 # Expose the port the app runs on
 EXPOSE 3000

--- a/worklenz-backend/Dockerfile
+++ b/worklenz-backend/Dockerfile
@@ -1,17 +1,21 @@
 # FIRST STAGE: Install Dependencies
 
 # Use the official Node.js 18-alpine3.20 image as a base
-FROM node:18-alpine3.20 as base
+FROM node:18 as builder
 
 # Create and set the working directory
 WORKDIR /usr/src/app
+
+# RUN apk add --no-cache --no-progress --virtual .gyp \
+#     python3 \
+#     make \
+#     g++ 
 
 # Install global dependencies
 RUN npm install -g ts-node typescript grunt grunt-cli
 
 # Copy package.json and package-lock.json (if available)
-COPY package*.json ./
-
+COPY package*.json .
 # Install app dependencies
 RUN npm ci
 
@@ -22,14 +26,13 @@ COPY . .
 RUN npm run build
 
 # SECOND STAGE: RUN THE APPLICATION
-
-
-FROM node:18-alpine3.20 as prod
+FROM node:18-alpine3.20 as runner
 
 WORKDIR /usr/src/app
 
-COPY --from=base /usr/src/app .
-
+COPY --from=builder /usr/src/app/build/package*.json .
+COPY --from=builder /usr/src/app/build dist/
+COPY --from=builder /usr/src/app/.env .
 # Expose the port the app runs on
 EXPOSE 3000
 

--- a/worklenz-frontend/Dockerfile
+++ b/worklenz-frontend/Dockerfile
@@ -1,14 +1,16 @@
 # STAGE 1: build
-FROM node:18-alpine3.20 as base
+FROM node:18-alpine3.20 as build
 
 WORKDIR /usr/src/app
-
 COPY . /usr/src/app
+# RUN npm i -g @angular/cli
+RUN npm install --silent
+ARG configuration=production
+RUN npm run build -- --output-path=/usr/src/app/dist/out --configuration $configuration
 
-RUN npm install -g @angular/cli
-
-RUN npm install
-
-CMD ["npm", "run", "start-docker"]
-
-# STAGE 2: Use compiled app for production with nginx
+# STAGE 2: Use built app for production with nginx
+FROM nginx:alpine3.19-slim
+COPY --from=build /usr/src/app/dist/out/ /usr/share/nginx/html
+COPY ./nginx/nginx-custom.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80 443
+CMD [ "nginx", "-g", "daemon off;" ]

--- a/worklenz-frontend/Dockerfile
+++ b/worklenz-frontend/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:alpine
+# STAGE 1: build
+FROM node:18-alpine3.20 as base
 
 WORKDIR /usr/src/app
 
@@ -9,3 +10,5 @@ RUN npm install -g @angular/cli
 RUN npm install
 
 CMD ["npm", "run", "start-docker"]
+
+# STAGE 2: Use compiled app for production with nginx

--- a/worklenz-frontend/nginx/nginx-custom.conf
+++ b/worklenz-frontend/nginx/nginx-custom.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
+    }
+}


### PR DESCRIPTION
This PR would bring the final image sizes of the docker build below 150MB, making it easier (Saves bandwidth) for any K8s pod or a docker run Instance to re-instantiate the application.

![build-images](https://github.com/Worklenz/worklenz/assets/13574074/44e7f7e2-7075-4fcc-a89c-fc40ad3e28f9)

The approach of multi-layered docker images are followed.

**Main Changes**

1. Instead of single worker of Angular app treating the client requests directly, we have utilized a nginx frontend which treats requests via port 80 and 443 (Not 4200).
2. Backend utilizes alpine images in runner stage. Though we wanted to use the same for `builder`, there are some alpine linux issues which forced us to make use of the same base image which used to work. Somehow, still the backend image could be resolved to 143MBs.
3. Frontend image size is 21.8 MB