### PR TITLE
Bind mount the postgres db volume with :z for selinux contexts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     networks:
       - worklenz
     volumes:
-      - worklenz_postgres_data:/var/lib/postgresql/data
+      - worklenz_postgres_data:/var/lib/postgresql/data:z
       - type: bind
         source: ./worklenz-backend/database
         target: /docker-entrypoint-initdb.d


### PR DESCRIPTION
This commit adds :z as bind mount options for the postgres db volume to address a deployment issues on host systems with SELinux enabled.