### PR TITLE
fix(service-worker): improve unregister logic for service workers

### DIFF
--- a/worklenz-frontend/public/unregister-sw.js
+++ b/worklenz-frontend/public/unregister-sw.js
@@ -1,7 +1,13 @@
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.getRegistrations().then(function(registrations) {
-    for(let registration of registrations) {
-      registration.unregister();
+    if (registrations.length > 0) {
+      // If there are registered service workers, do a hard reload first
+      window.location.reload(true);
+    } else {
+      // If no service workers are registered, unregister any that might be pending
+      for(let registration of registrations) {
+        registration.unregister();
+      }
     }
   });
 } 


### PR DESCRIPTION
- Updated the unregister script to first check for registered service workers and perform a hard reload if any are found.
- If no service workers are registered, the script will now properly unregister any pending registrations, enhancing the service worker lifecycle management.