### PR TITLE
fix(service-worker): prevent multiple unregister attempts in session

### DIFF
--- a/worklenz-frontend/public/unregister-sw.js
+++ b/worklenz-frontend/public/unregister-sw.js
@@ -1,13 +1,18 @@
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.getRegistrations().then(function(registrations) {
-    if (registrations.length > 0) {
-      // If there are registered service workers, do a hard reload first
-      window.location.reload(true);
-    } else {
-      // If no service workers are registered, unregister any that might be pending
-      for(let registration of registrations) {
-        registration.unregister();
+  // Check if we've already attempted to unregister in this session
+  if (!sessionStorage.getItem('swUnregisterAttempted')) {
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+      if (registrations.length > 0) {
+        // Mark that we've attempted to unregister
+        sessionStorage.setItem('swUnregisterAttempted', 'true');
+        // If there are registered service workers, do a hard reload first
+        window.location.reload(true);
+      } else {
+        // If no service workers are registered, unregister any that might be pending
+        for(let registration of registrations) {
+          registration.unregister();
+        }
       }
-    }
-  });
+    });
+  }
 } 


### PR DESCRIPTION
- Updated the unregister script to check if an attempt to unregister service workers has already been made in the current session, preventing unnecessary reloads and improving user experience.
- If service workers are registered, the script will perform a hard reload; otherwise, it will unregister any pending registrations.