### PR TITLE
refactor(config): migrate configuration files to ES module syntax

### DIFF
--- a/worklenz-frontend/jest.config.js
+++ b/worklenz-frontend/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',

--- a/worklenz-frontend/postcss.config.js
+++ b/worklenz-frontend/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/worklenz-frontend/tailwind.config.js
+++ b/worklenz-frontend/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {},

--- a/worklenz-frontend/vite.config.ts
+++ b/worklenz-frontend/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(({ command, mode }) => {
   const isProduction = command === 'build';
@@ -10,10 +9,6 @@ export default defineConfig(({ command, mode }) => {
     // **Plugins**
     plugins: [
       react(),
-      tsconfigPaths({
-        // Optionally, you can specify a custom tsconfig file
-        // loose: true, // If you're using a non-standard tsconfig setup
-      }),
     ],
 
     // **Resolve**


### PR DESCRIPTION
- Updated jest.config.js, postcss.config.js, and tailwind.config.js to use ES module export syntax.
- Removed unused tsconfigPaths import from vite.config.ts to streamline the configuration.