### PR TITLE
refactor(enhanced-kanban): update state management for editable section

### DIFF
--- a/worklenz-frontend/src/components/project-task-filters/delete-status-drawer/delete-status-drawer.tsx
+++ b/worklenz-frontend/src/components/project-task-filters/delete-status-drawer/delete-status-drawer.tsx
@@ -15,7 +15,7 @@ import { useSelector } from 'react-redux';
 import {
     deleteSection,
     IGroupBy,
-} from '@features/board/board-slice';
+} from '@features/enhanced-kanban/enhanced-kanban.slice';
 import { statusApiService } from '@/api/taskAttributes/status/status.api.service';
 import { phasesApiService } from '@/api/taskAttributes/phases/phases.api.service';
 import logger from '@/utils/errorLogger';
@@ -31,7 +31,7 @@ const DeleteStatusDrawer: React.FC = () => {
     const { projectView } = useTabSearchParam();
     const [form] = Form.useForm();
     const { t } = useTranslation('task-list-filters');
-    const { editableSectionId, groupBy } = useAppSelector(state => state.boardReducer);
+    const { editableSectionId, groupBy } = useAppSelector(state => state.enhancedKanbanReducer);
     const isDelteStatusDrawerOpen = useAppSelector(
         state => state.deleteStatusReducer.isDeleteStatusDrawerOpen
     );

--- a/worklenz-frontend/src/features/enhanced-kanban/enhanced-kanban.slice.ts
+++ b/worklenz-frontend/src/features/enhanced-kanban/enhanced-kanban.slice.ts
@@ -101,6 +101,7 @@ interface EnhancedKanbanState {
   selectedTaskIds: string[];
   expandedSubtasks: Record<string, boolean>;
   columnOrder: string[];
+  editableSectionId: string | null;
 }
 
 const initialState: EnhancedKanbanState = {
@@ -141,6 +142,7 @@ const initialState: EnhancedKanbanState = {
   selectedTaskIds: [],
   expandedSubtasks: {},
   columnOrder: [],
+  editableSectionId: null,
 };
 
 // Performance monitoring utility
@@ -372,8 +374,6 @@ const deleteTaskFromGroup = (
     }
   }
 };
-
-
 
 const enhancedKanbanSlice = createSlice({
   name: 'enhancedKanbanReducer',
@@ -871,6 +871,19 @@ const enhancedKanbanSlice = createSlice({
         state.groupCache[result.groupId] = result.group;
       }
     },
+
+    setEditableSection: (state, action: PayloadAction<string | null>) => {
+      state.editableSectionId = action.payload;
+    },
+
+    deleteSection: (state, action: PayloadAction<{ sectionId: string }>) => {
+      state.taskGroups = state.taskGroups.filter(
+        section => section.id !== action.payload.sectionId
+      );
+      if (state.editableSectionId === action.payload.sectionId) {
+        state.editableSectionId = null;
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -1061,6 +1074,8 @@ export const {
   updateEnhancedKanbanTaskStartDate,
   updateEnhancedKanbanSubtask,
   toggleTaskExpansion,
+  setEditableSection,
+  deleteSection,
 } = enhancedKanbanSlice.actions;
 
 export default enhancedKanbanSlice.reducer; 


### PR DESCRIPTION
- Changed the source of `editableSectionId` from `boardReducer` to `enhancedKanbanReducer` for improved state organization.
- Added `setEditableSection` and `deleteSection` actions to manage the editable section state within the enhanced kanban slice.