### PR TITLE
feat(localization): add new translations for Kanban board sections

### DIFF
--- a/worklenz-frontend/public/locales/alb/kanban-board.json
+++ b/worklenz-frontend/public/locales/alb/kanban-board.json
@@ -19,5 +19,7 @@
   "archive": "Arkivo",
 
   "newTaskNamePlaceholder": "Shkruaj emrin e detyrës",
-  "newSubtaskNamePlaceholder": "Shkruaj emrin e nëndetyrës"
+  "newSubtaskNamePlaceholder": "Shkruaj emrin e nëndetyrës",
+  "untitledSection": "Seksion pa titull",
+  "unmapped": "Pa hartë"
 }

--- a/worklenz-frontend/public/locales/de/kanban-board.json
+++ b/worklenz-frontend/public/locales/de/kanban-board.json
@@ -19,5 +19,7 @@
   "archive": "Archivieren",
 
   "newTaskNamePlaceholder": "Aufgabenname eingeben",
-  "newSubtaskNamePlaceholder": "Unteraufgabenname eingeben"
+  "newSubtaskNamePlaceholder": "Unteraufgabenname eingeben",
+  "untitledSection": "Unbenannter Abschnitt",
+  "unmapped": "Nicht zugeordnet"
 }

--- a/worklenz-frontend/public/locales/en/kanban-board.json
+++ b/worklenz-frontend/public/locales/en/kanban-board.json
@@ -19,5 +19,7 @@
   "archive": "Archive",
 
   "newTaskNamePlaceholder": "Write a task Name",
-  "newSubtaskNamePlaceholder": "Write a subtask Name"
+  "newSubtaskNamePlaceholder": "Write a subtask Name",
+  "untitledSection": "Untitled section",
+  "unmapped": "Unmapped"
 }

--- a/worklenz-frontend/public/locales/es/kanban-board.json
+++ b/worklenz-frontend/public/locales/es/kanban-board.json
@@ -19,5 +19,7 @@
   "archive": "Archivar",
 
   "newTaskNamePlaceholder": "Escribe un nombre de tarea",
-  "newSubtaskNamePlaceholder": "Escribe un nombre de subtarea"
+  "newSubtaskNamePlaceholder": "Escribe un nombre de subtarea",
+  "untitledSection": "Sección sin título",
+  "unmapped": "Sin asignar"
 }

--- a/worklenz-frontend/public/locales/pt/kanban-board.json
+++ b/worklenz-frontend/public/locales/pt/kanban-board.json
@@ -19,5 +19,7 @@
   "archive": "Arquivar",
 
   "newTaskNamePlaceholder": "Escreva um nome de tarefa",
-  "newSubtaskNamePlaceholder": "Escreva um nome de subtarefa"
+  "newSubtaskNamePlaceholder": "Escreva um nome de subtarefa",
+  "untitledSection": "Seção sem título",
+  "unmapped": "Não mapeado"
 }

--- a/worklenz-frontend/src/components/enhanced-kanban/EnhancedKanbanBoardNativeDnD/KanbanGroup.tsx
+++ b/worklenz-frontend/src/components/enhanced-kanban/EnhancedKanbanBoardNativeDnD/KanbanGroup.tsx
@@ -125,7 +125,7 @@ const KanbanGroup: React.FC<KanbanGroupProps> = memo(({
     const handleBlur = async () => {
         setIsEditable(false);
         if (name === editName) return;
-        if (name === 'Untitled section') {
+        if (name === t('untitledSection')) {
             dispatch(fetchEnhancedKanbanGroups(projectId ?? ''));
         }
 
@@ -249,7 +249,7 @@ const KanbanGroup: React.FC<KanbanGroupProps> = memo(({
                         className="flex items-center gap-2 cursor-pointer"
                         onClick={e => {
                             e.stopPropagation();
-                            if ((isProjectManager || isOwnerOrAdmin) && group.name !== 'Unmapped')
+                            if ((isProjectManager || isOwnerOrAdmin) && group.name !== t('unmapped'))
                                 setIsEditable(true);
                         }}
                         onMouseDown={e => {
@@ -312,7 +312,7 @@ const KanbanGroup: React.FC<KanbanGroupProps> = memo(({
                             </svg>
                         </button>
 
-                        {(isOwnerOrAdmin || isProjectManager) && name !== 'Unmapped' && (
+                        {(isOwnerOrAdmin || isProjectManager) && name !== t('unmapped') && (
                             <div className="relative" ref={dropdownRef}>
                                 <button
                                     type="button"
@@ -341,7 +341,7 @@ const KanbanGroup: React.FC<KanbanGroupProps> = memo(({
                                             {groupBy === IGroupBy.STATUS && statusCategories && (
                                                 <div className="border-t border-gray-200 dark:border-gray-700">
                                                     <div className="px-4 py-2 text-xs font-medium text-gray-500 uppercase tracking-wide">
-                                                        Change category
+                                                        {t('changeCategory')}
                                                     </div>
                                                     {statusCategories.map(status => (
                                                         <button


### PR DESCRIPTION
- Introduced translations for "untitledSection" and "unmapped" in multiple languages including Albanian, German, English, Spanish, and Portuguese.
- Updated KanbanGroup component to utilize these new translations for improved internationalization support.