### PR TITLE
refactor(navbar): remove unused subscription types from navbar component

### DIFF
--- a/worklenz-frontend/src/features/navbar/navbar.tsx
+++ b/worklenz-frontend/src/features/navbar/navbar.tsx
@@ -36,9 +36,6 @@ const Navbar = () => {
   const [isOwnerOrAdmin, setIsOwnerOrAdmin] = useState<boolean>(authService.isOwnerOrAdmin());
   const showUpgradeTypes = [
     ISUBSCRIPTION_TYPE.TRIAL,
-    ISUBSCRIPTION_TYPE.LIFE_TIME_DEAL,
-    ISUBSCRIPTION_TYPE.PADDLE,
-    ISUBSCRIPTION_TYPE.CUSTOM
   ];
 
   useEffect(() => {


### PR DESCRIPTION
- Eliminated `LIFE_TIME_DEAL`, `PADDLE`, and `CUSTOM` subscription types from the `showUpgradeTypes` array in the `Navbar` component for improved clarity and reduced complexity.