### PR TITLE
fix(docker): Update docker-compose.yml to fix broken postgress and MinIO initialization.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,24 +55,9 @@ services:
     depends_on:
       - minio
     restart: on-failure
-    entrypoint: >
-      /bin/sh -c '
-        echo "Waiting for MinIO to start...";
-        sleep 15;
-        for i in 1 2 3 4 5; do
-          echo "Attempt $i to connect to MinIO...";
-          if /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin; then
-            echo "Successfully connected to MinIO!";
-            /usr/bin/mc mb --ignore-existing myminio/worklenz-bucket;
-            /usr/bin/mc policy set public myminio/worklenz-bucket;
-            exit 0;
-          fi
-          echo "Connection failed, retrying in 5 seconds...";
-          sleep 5;
-        done;
-        echo "Failed to connect to MinIO after 5 attempts";
-        exit 1;
-            '
+    entrypoint: ["/bin/sh", "/scripts/createbuckets-entrypoint.sh"]
+    volumes:
+      - ./docker/createbuckets-entrypoint.sh:/scripts/createbuckets-entrypoint.sh:ro
     networks:
       - worklenz
   db:
@@ -96,6 +81,7 @@ services:
       - worklenz
     volumes:
       - worklenz_postgres_data:/var/lib/postgresql/data
+      - ./docker/db-init-wrapper.sh:/usr/local/bin/db-init-wrapper.sh:ro
       - type: bind
         source: ./worklenz-backend/database/sql
         target: /docker-entrypoint-initdb.d/sql
@@ -111,23 +97,7 @@ services:
       - type: bind
         source: ./pg_backups
         target: /docker-entrypoint-initdb.d/pg_backups
-    command: >
-        bash -c '
-          if command -v apt-get >/dev/null 2>&1; then
-            apt-get update && apt-get install -y dos2unix
-          elif command -v apk >/dev/null 2>&1; then
-            apk add --no-cache dos2unix
-          fi
-
-          find /docker-entrypoint-initdb.d -type f -name "*.sh" -exec sh -c '"'"'
-            for f; do
-              dos2unix "$f" 2>/dev/null || true
-              chmod +x "$f"
-            done
-          '"'"' sh {} +
-
-          exec docker-entrypoint.sh postgres
-        '
+    command: ["/usr/local/bin/db-init-wrapper.sh"]
   db-backup:
     image: postgres:15
     container_name: worklenz_db_backup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - worklenz

--- a/docker/createbuckets-entrypoint.sh
+++ b/docker/createbuckets-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for MinIO to start..."
+sleep 15
+
+for i in 1 2 3 4 5; do
+  echo "Attempt $i to connect to MinIO..."
+  if /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin; then
+    echo "Successfully connected to MinIO!"
+    /usr/bin/mc mb --ignore-existing myminio/worklenz-bucket
+    /usr/bin/mc policy set public myminio/worklenz-bucket
+    exit 0
+  fi
+
+  echo "Connection failed, retrying in 5 seconds..."
+  sleep 5
+done
+
+echo "Failed to connect to MinIO after 5 attempts"
+exit 1
+

--- a/docker/db-init-wrapper.sh
+++ b/docker/db-init-wrapper.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# Install dos2unix if possible
+if command -v apt-get >/dev/null 2>&1; then
+  apt-get update && apt-get install -y dos2unix
+elif command -v apk >/dev/null 2>&1; then
+  apk add --no-cache dos2unix
+fi
+
+# Normalize and chmod all .sh files
+for f in /docker-entrypoint-initdb.d/*.sh; do
+  if [ -f "$f" ]; then
+    dos2unix "$f" 2>/dev/null || true
+    chmod +x "$f"
+  fi
+done
+
+# hand control to the real entrypoint
+exec docker-entrypoint.sh postgres
+


### PR DESCRIPTION
This PR fixes multiple issues with the provided docker-compose.yml setup that were preventing a clean deployment of Worklenz.

## Problems identified
### Problem 1
Inline init commands in Compose were triggering Docker variable substitution warnings ($i, $f), causing broken init scripts and migration failures.

```bash
WARN[0000] The "i" variable is not set. Defaulting to a blank string. 
WARN[0000] The "f" variable is not set. Defaulting to a blank string. 
WARN[0000] The "f" variable is not set. Defaulting to a blank string.
```

So what happens here is that docker compose tries to substitute all $VARIABLE strings. So inline scripts such as:
```bash
command: >
    bash -c '
      find /docker-entrypoint-initdb.d -type f -name "*.sh" -exec sh -c '"'"'
        for f; do
          dos2unix "$f" 2>/dev/null || true
          chmod +x "$f"
        done
      '"'"' sh {} +
      exec docker-entrypoint.sh postgres
    '
```

Will have their $f replaced with empty strings that leads to:
```bash
chmod: cannot access '': No such file or directory
```

### Problem 2
Postgres healthcheck was running too early (before initdb, dos2unix install, and migrations finished), causing the container to be marked unhealthy and dependent services to fail.

```bash
worklenz_db | CREATE DATABASE 
worklenz_db | 
worklenz_db | 
worklenz_db | /usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/00_init.sh 
worklenz_db | Starting database initialization... 
dependency failed to start: container worklenz_db is unhealthy
```

Fixes applied

1. Moved inline init commands into standalone scripts:
- `docker/db-init-wrapper.sh` – runs dos2unix + chmod safely without Compose substitution conflicts.
- `docker/createbuckets-entrypoint.sh` – encapsulates MinIO bucket creation logic.


2. Updated Postgres db service to use healthcheck start_period of 30s so the healthcheck waits for initialization before running.

Should fix #325