### PR TITLE
fix error function get_task_complete_ratio - division by zero

### DIFF
--- a/worklenz-backend/database/sql/4_functions.sql
+++ b/worklenz-backend/database/sql/4_functions.sql
@@ -3418,8 +3418,9 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION get_task_complete_ratio(_task_id uuid) RETURNS json
-    LANGUAGE plpgsql
+CREATE OR REPLACE FUNCTION get_task_complete_ratio(_task_id uuid)
+RETURNS json
+LANGUAGE plpgsql
 AS
 $$
 DECLARE
@@ -3430,33 +3431,49 @@ DECLARE
     _total_tasks      FLOAT = 0;
     _ratio            FLOAT = 0;
 BEGIN
+    -- Check if parent task itself is done
     SELECT (CASE
-                WHEN EXISTS(SELECT 1
-                            FROM tasks_with_status_view
-                            WHERE tasks_with_status_view.task_id = _task_id
-                              AND is_done IS TRUE) THEN 1
-                ELSE 0 END)
+                WHEN EXISTS(
+                    SELECT 1
+                    FROM tasks_with_status_view
+                    WHERE task_id = _task_id
+                      AND is_done IS TRUE
+                ) THEN 1
+                ELSE 0
+            END)
     INTO _parent_task_done;
-    SELECT COUNT(*) FROM tasks WHERE parent_task_id = _task_id AND archived IS FALSE INTO _sub_tasks_count;
 
+    -- Count subtasks
+    SELECT COUNT(*)
+    FROM tasks
+    WHERE parent_task_id = _task_id
+      AND archived IS FALSE
+    INTO _sub_tasks_count;
+
+    -- Count completed subtasks
     SELECT COUNT(*)
     FROM tasks_with_status_view
     WHERE parent_task_id = _task_id
       AND is_done IS TRUE
     INTO _sub_tasks_done;
 
-    _total_completed = _parent_task_done + _sub_tasks_done;
---     _total_tasks = _sub_tasks_count + 1; -- +1 for the parent task
-    _total_tasks = _sub_tasks_count; -- +1 for the parent task
-    _ratio = (_total_completed / _total_tasks) * 100;
+    _total_completed := _parent_task_done + _sub_tasks_done;
+    _total_tasks := _sub_tasks_count; -- currently not counting parent task
+
+    -- Avoid division by zero
+    _ratio := CASE
+                  WHEN _total_tasks = 0 THEN 0
+                  ELSE (_total_completed / _total_tasks) * 100
+              END;
 
     RETURN JSON_BUILD_OBJECT(
         'ratio', _ratio,
         'total_completed', _total_completed,
         'total_tasks', _total_tasks
-        );
-END
+    );
+END;
 $$;
+
 
 CREATE OR REPLACE FUNCTION get_task_form_view_model(_user_id uuid, _team_id uuid, _task_id uuid, _project_id uuid) RETURNS json
     LANGUAGE plpgsql


### PR DESCRIPTION
I've encountered the error: 
"worklenz error: [1] at process.processImmediate (node:internal/timers:511:21) { [1] length: 154, [1] severity: 'ERROR', [1] code: '22012', [1] detail: undefined, [1] hint: undefined, [1] position: undefined, [1] internalPosition: undefined, [1] internalQuery: undefined, [1] where: 'PL/pgSQL function get_task_complete_ratio(uuid) line 28 at assignment', [1] schema: undefined, [1] table: undefined, [1] column: undefined, [1] dataType: undefined, [1] constraint: undefined, [1] file: 'float.c', [1] line: '105',"


I edited the sql and it works for me