### PR TITLE
set image name to lowercase

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout the codebase
         uses: actions/checkout@v4
 
+      - name: Set image name to lowercase
+        run: echo "IMAGE_BASE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/worklenz" >> $GITHUB_ENV
+
       - name: Login to the Container registry
         uses: docker/login-action@v3
         with:
@@ -37,7 +40,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.service.container_name }}
+          images: ${{ env.IMAGE_BASE }}-${{ matrix.service.name }}
           flavor: |
             latest=true     
 


### PR DESCRIPTION
It seems that image building currently fails.
This PR uses Bash parameter expansion from the other solutions to lowercase the image.

See also #29 and these:

- https://github.com/orgs/community/discussions/25768
- https://stackoverflow.com/questions/48522615/docker-error-invalid-reference-format-repository-name-must-be-lowercase
- https://github.com/orgs/community/discussions/27086
- https://github.com/docker/build-push-action/issues/37