### PR TITLE
feat(operations): add read-only cases API foundation

### DIFF
--- a/worklenz-backend/database/migrations/20260615000000-operational-cases.sql
+++ b/worklenz-backend/database/migrations/20260615000000-operational-cases.sql
@@ -1,0 +1,125 @@
+-- Minimal read-only operations foundation for cases used by operations views.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'operational_case_type') THEN
+        CREATE TYPE operational_case_type AS ENUM (
+            'supplier_order',
+            'repair',
+            'shipment',
+            'general'
+        );
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'operational_case_status') THEN
+        CREATE TYPE operational_case_status AS ENUM (
+            'new',
+            'waiting_internal',
+            'waiting_external',
+            'in_progress',
+            'at_risk',
+            'overdue',
+            'done',
+            'closed_problem'
+        );
+    END IF;
+END
+$$;
+
+CREATE OR REPLACE PROCEDURE pg_temp.add_constraint(_table TEXT, _constraint TEXT, _definition TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = _constraint) THEN
+        EXECUTE FORMAT('ALTER TABLE %I ADD CONSTRAINT %I %s', _table, _constraint, _definition);
+    END IF;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS counterparties (
+    id               UUID                     DEFAULT uuid_generate_v4() NOT NULL,
+    team_id          UUID                                                NOT NULL,
+    name             TEXT                                                NOT NULL,
+    type             TEXT                                                NOT NULL,
+    created_at       TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    updated_at       TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL
+);
+
+CALL pg_temp.add_constraint('counterparties', 'counterparties_pk', 'PRIMARY KEY (id)');
+CALL pg_temp.add_constraint('counterparties', 'counterparties_team_id_fk', 'FOREIGN KEY (team_id) REFERENCES teams ON DELETE CASCADE');
+CALL pg_temp.add_constraint('counterparties', 'counterparties_type_check', 'CHECK (type = ANY (ARRAY [''supplier''::TEXT, ''broker''::TEXT, ''repair_service''::TEXT, ''carrier''::TEXT, ''customer''::TEXT, ''internal''::TEXT, ''other''::TEXT]))');
+
+CREATE UNIQUE INDEX IF NOT EXISTS counterparties_name_type_team_uindex
+    ON counterparties (LOWER(name), type, team_id);
+
+CREATE TABLE IF NOT EXISTS assets (
+    id           UUID                     DEFAULT uuid_generate_v4() NOT NULL,
+    team_id      UUID                                                NOT NULL,
+    name         TEXT                                                NOT NULL,
+    inventory_no TEXT,
+    created_at   TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    updated_at   TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL
+);
+
+CALL pg_temp.add_constraint('assets', 'assets_pk', 'PRIMARY KEY (id)');
+CALL pg_temp.add_constraint('assets', 'assets_team_id_fk', 'FOREIGN KEY (team_id) REFERENCES teams ON DELETE CASCADE');
+
+CREATE UNIQUE INDEX IF NOT EXISTS assets_inventory_no_team_uindex
+    ON assets (team_id, inventory_no)
+    WHERE inventory_no IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS operational_cases (
+    id                  UUID                     DEFAULT uuid_generate_v4() NOT NULL,
+    team_id             UUID                                                NOT NULL,
+    project_id          UUID,
+    title               TEXT                                                NOT NULL,
+    description         TEXT,
+    case_type           operational_case_type                               NOT NULL,
+    status              operational_case_status  DEFAULT 'new'              NOT NULL,
+    owner_id            UUID                                                NOT NULL,
+    counterparty_id     UUID,
+    asset_id            UUID,
+    due_date            TIMESTAMP WITH TIME ZONE,
+    external_wait_since TIMESTAMP WITH TIME ZONE,
+    last_activity_at    TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    priority_score      NUMERIC                  DEFAULT 0                  NOT NULL,
+    risk_score          NUMERIC                  DEFAULT 0                  NOT NULL,
+    no_deadline_reason  TEXT,
+    created_at          TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    updated_at          TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL
+);
+
+CALL pg_temp.add_constraint('operational_cases', 'operational_cases_pk', 'PRIMARY KEY (id)');
+CALL pg_temp.add_constraint('operational_cases', 'operational_cases_team_id_fk', 'FOREIGN KEY (team_id) REFERENCES teams ON DELETE CASCADE');
+CALL pg_temp.add_constraint('operational_cases', 'operational_cases_project_id_fk', 'FOREIGN KEY (project_id) REFERENCES projects ON DELETE SET NULL');
+CALL pg_temp.add_constraint('operational_cases', 'operational_cases_owner_id_fk', 'FOREIGN KEY (owner_id) REFERENCES users ON DELETE RESTRICT');
+CALL pg_temp.add_constraint('operational_cases', 'operational_cases_counterparty_id_fk', 'FOREIGN KEY (counterparty_id) REFERENCES counterparties ON DELETE SET NULL');
+CALL pg_temp.add_constraint('operational_cases', 'operational_cases_asset_id_fk', 'FOREIGN KEY (asset_id) REFERENCES assets ON DELETE SET NULL');
+
+CREATE INDEX IF NOT EXISTS operational_cases_team_status_index
+    ON operational_cases (team_id, status);
+
+CREATE INDEX IF NOT EXISTS operational_cases_team_due_date_index
+    ON operational_cases (team_id, due_date);
+
+CREATE INDEX IF NOT EXISTS operational_cases_team_type_index
+    ON operational_cases (team_id, case_type);
+
+CREATE TABLE IF NOT EXISTS money_impacts (
+    id                    UUID                     DEFAULT uuid_generate_v4() NOT NULL,
+    case_id               UUID                                                NOT NULL,
+    currency              TEXT                     DEFAULT 'RUB'::TEXT        NOT NULL,
+    object_value          NUMERIC,
+    service_cost          NUMERIC,
+    potential_loss        NUMERIC,
+    downtime_cost_per_day NUMERIC,
+    delay_cost_per_day    NUMERIC,
+    created_at            TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL,
+    updated_at            TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP  NOT NULL
+);
+
+CALL pg_temp.add_constraint('money_impacts', 'money_impacts_pk', 'PRIMARY KEY (id)');
+CALL pg_temp.add_constraint('money_impacts', 'money_impacts_case_id_fk', 'FOREIGN KEY (case_id) REFERENCES operational_cases ON DELETE CASCADE');
+
+CREATE UNIQUE INDEX IF NOT EXISTS money_impacts_case_id_uindex
+    ON money_impacts (case_id);

--- a/worklenz-backend/database/migrations/20260616000000-operational-case-next-action.sql
+++ b/worklenz-backend/database/migrations/20260616000000-operational-case-next-action.sql
@@ -1,0 +1,6 @@
+ALTER TABLE operational_cases
+    ADD COLUMN IF NOT EXISTS next_action_text TEXT,
+    ADD COLUMN IF NOT EXISTS next_action_due_date TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX IF NOT EXISTS operational_cases_team_next_action_due_date_index
+    ON operational_cases (team_id, next_action_due_date);

--- a/worklenz-backend/database/migrations/20260619000000-operational-order-number.sql
+++ b/worklenz-backend/database/migrations/20260619000000-operational-order-number.sql
@@ -1,0 +1,6 @@
+ALTER TABLE operational_cases
+    ADD COLUMN IF NOT EXISTS order_number TEXT;
+
+CREATE INDEX IF NOT EXISTS operational_cases_team_order_number_index
+    ON operational_cases (team_id, LOWER(order_number))
+    WHERE order_number IS NOT NULL;

--- a/worklenz-backend/src/controllers/cases-controller.ts
+++ b/worklenz-backend/src/controllers/cases-controller.ts
@@ -1,0 +1,117 @@
+import db from "../config/db";
+import HandleExceptions from "../decorators/handle-exceptions";
+import {IWorkLenzRequest} from "../interfaces/worklenz-request";
+import {IWorkLenzResponse} from "../interfaces/worklenz-response";
+import {ServerResponse} from "../models/server-response";
+import WorklenzControllerBase from "./worklenz-controller-base";
+
+const CASE_TYPE_FILTERS = new Set(["supplier_order", "repair", "shipment", "general"]);
+const CASE_STATUS_FILTERS = new Set([
+  "new",
+  "waiting_internal",
+  "waiting_external",
+  "in_progress",
+  "at_risk",
+  "overdue",
+  "done",
+  "closed_problem"
+]);
+
+export default class CasesController extends WorklenzControllerBase {
+  @HandleExceptions()
+  public static async get(req: IWorkLenzRequest, res: IWorkLenzResponse): Promise<IWorkLenzResponse> {
+    const {
+      searchQuery,
+      searchParams,
+      sortField,
+      sortOrder,
+      size,
+      offset
+    } = this.toPaginationOptions(req.query, ["oc.title", "oc.description", "oc.order_number"], false, 4);
+    const allowedSortFields: Record<string, string> = {
+      title: "oc.title",
+      due_date: "oc.due_date",
+      status: "oc.status",
+      case_type: "oc.case_type",
+      priority_score: "oc.priority_score",
+      risk_score: "oc.risk_score",
+      updated_at: "oc.updated_at",
+      created_at: "oc.created_at"
+    };
+    const orderBy = allowedSortFields[String(sortField)] || "oc.updated_at";
+    const queryParams: unknown[] = [req.user?.team_id, size, offset, ...searchParams];
+    let filters = searchQuery;
+
+    if (typeof req.query.case_type === "string" && CASE_TYPE_FILTERS.has(req.query.case_type)) {
+      queryParams.push(req.query.case_type);
+      filters += ` AND oc.case_type = $${queryParams.length}`;
+    }
+
+    if (typeof req.query.status === "string" && CASE_STATUS_FILTERS.has(req.query.status)) {
+      queryParams.push(req.query.status);
+      filters += ` AND oc.status = $${queryParams.length}`;
+    }
+
+    const q = `
+      SELECT ROW_TO_JSON(rec) AS cases
+      FROM (
+        SELECT COUNT(*) AS total,
+          (
+            SELECT COALESCE(ARRAY_TO_JSON(ARRAY_AGG(ROW_TO_JSON(t))), '[]'::JSON)
+            FROM (
+              SELECT
+                oc.id,
+                oc.team_id,
+                oc.title,
+                oc.order_number,
+                oc.description,
+                oc.case_type,
+                oc.status,
+                p.name AS project_name,
+                cp.name AS counterparty_name,
+                cp.type AS counterparty_type,
+                a.name AS asset_name,
+                a.inventory_no AS asset_inventory_no,
+                oc.due_date,
+                oc.next_action_text,
+                oc.next_action_due_date,
+                oc.external_wait_since,
+                oc.last_activity_at,
+                oc.priority_score,
+                oc.risk_score,
+                oc.no_deadline_reason,
+                oc.created_at,
+                oc.updated_at,
+                COALESCE(mi.currency, 'RUB') AS money_currency,
+                COALESCE(mi.object_value, 0)
+                  + COALESCE(mi.service_cost, 0)
+                  + COALESCE(mi.potential_loss, 0) AS money_impact_total,
+                jsonb_strip_nulls(
+                  jsonb_build_object(
+                    'currency', mi.currency,
+                    'object_value', mi.object_value,
+                    'service_cost', mi.service_cost,
+                    'potential_loss', mi.potential_loss,
+                    'downtime_cost_per_day', mi.downtime_cost_per_day,
+                    'delay_cost_per_day', mi.delay_cost_per_day
+                  )
+                ) AS money_impact
+              FROM operational_cases oc
+              LEFT JOIN projects p ON p.id = oc.project_id AND p.team_id = oc.team_id
+              LEFT JOIN counterparties cp ON cp.id = oc.counterparty_id AND cp.team_id = oc.team_id
+              LEFT JOIN assets a ON a.id = oc.asset_id AND a.team_id = oc.team_id
+              LEFT JOIN money_impacts mi ON mi.case_id = oc.id
+              WHERE oc.team_id = $1 ${filters}
+              ORDER BY ${orderBy} ${sortOrder}
+              LIMIT $2 OFFSET $3
+            ) t
+          ) AS data
+        FROM operational_cases oc
+        WHERE oc.team_id = $1 ${filters}
+      ) rec;
+    `;
+    const result = await db.query(q, queryParams);
+    const [data] = result.rows;
+    return res.status(200).send(new ServerResponse(true, data?.cases || this.paginatedDatasetDefaultStruct));
+  }
+}

--- a/worklenz-backend/src/routes/apis/cases-api-router.ts
+++ b/worklenz-backend/src/routes/apis/cases-api-router.ts
@@ -1,0 +1,10 @@
+import express from "express";
+
+import CasesController from "../../controllers/cases-controller";
+import safeControllerFunction from "../../shared/safe-controller-function";
+
+const casesApiRouter = express.Router();
+
+casesApiRouter.get("/", safeControllerFunction(CasesController.get));
+
+export default casesApiRouter;

--- a/worklenz-backend/src/routes/apis/index.ts
+++ b/worklenz-backend/src/routes/apis/index.ts
@@ -62,6 +62,7 @@ import customColumnsApiRouter from "./custom-columns-api-router";
 import userActivityLogsApiRouter from "./user-activity-logs-api-router";
 import supportApiRouter from "./support-api-router";
 import accountApiRouter from "./account-api-router";
+import casesApiRouter from "./cases-api-router";
 
 const api = express.Router();
 
@@ -124,6 +125,7 @@ api.use("/task-recurring", taskRecurringApiRouter);
 api.use("/custom-columns", customColumnsApiRouter);
 api.use("/support", supportApiRouter);
 api.use("/account", accountApiRouter);
+api.use("/cases", casesApiRouter);
 
 api.use("/logs", userActivityLogsApiRouter);
 export default api;

--- a/worklenz-frontend/src/api/operations/operations.api.service.ts
+++ b/worklenz-frontend/src/api/operations/operations.api.service.ts
@@ -1,0 +1,36 @@
+import { API_BASE_URL } from '@/shared/constants';
+import { IServerResponse } from '@/types/common.types';
+import {
+  IOperationalCasesResponse,
+  OperationalCaseStatus,
+  OperationalCaseType,
+} from '@/types/operations/operations.types';
+import apiClient from '../api-client';
+
+const rootUrl = `${API_BASE_URL}/cases`;
+
+export const operationsApiService = {
+  getCases: async (params?: {
+    case_type?: OperationalCaseType | 'all';
+    status?: OperationalCaseStatus | 'all';
+    search?: string;
+  }): Promise<IServerResponse<IOperationalCasesResponse>> => {
+    const searchParams = new URLSearchParams();
+
+    if (params?.case_type && params.case_type !== 'all') {
+      searchParams.set('case_type', params.case_type);
+    }
+    if (params?.status && params.status !== 'all') {
+      searchParams.set('status', params.status);
+    }
+    if (params?.search) {
+      searchParams.set('search', params.search);
+    }
+
+    const query = searchParams.toString();
+    const response = await apiClient.get<IServerResponse<IOperationalCasesResponse>>(
+      `${rootUrl}${query ? `?${query}` : ''}`
+    );
+    return response.data;
+  },
+};

--- a/worklenz-frontend/src/types/operations/operations.types.ts
+++ b/worklenz-frontend/src/types/operations/operations.types.ts
@@ -1,0 +1,53 @@
+export type OperationalCaseType = 'supplier_order' | 'repair' | 'shipment' | 'general';
+
+export type OperationalCaseStatus =
+  | 'new'
+  | 'waiting_internal'
+  | 'waiting_external'
+  | 'in_progress'
+  | 'at_risk'
+  | 'overdue'
+  | 'done'
+  | 'closed_problem';
+
+export interface IMoneyImpact {
+  currency?: string | null;
+  object_value?: number | null;
+  service_cost?: number | null;
+  potential_loss?: number | null;
+  downtime_cost_per_day?: number | null;
+  delay_cost_per_day?: number | null;
+}
+
+export interface IOperationalCase {
+  id: string;
+  team_id?: string;
+  title: string;
+  order_number?: string | null;
+  description?: string | null;
+  case_type: OperationalCaseType;
+  status: OperationalCaseStatus;
+  project_name?: string | null;
+  counterparty_name?: string | null;
+  counterparty_type?: string | null;
+  asset_name?: string | null;
+  asset_inventory_no?: string | null;
+  due_date?: string | null;
+  next_action_text?: string | null;
+  next_action_due_date?: string | null;
+  external_wait_since?: string | null;
+  last_activity_at?: string | null;
+  priority_score?: number | null;
+  risk_score?: number | null;
+  no_deadline_reason?: string | null;
+  money_currency?: string | null;
+  money_impact?: IMoneyImpact;
+  money_impact_total?: number | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface IOperationalCasesResponse {
+  total: number;
+  data: IOperationalCase[];
+}


### PR DESCRIPTION
## Summary

Adds a minimal read-only Operations Cases foundation.

## What changed

- Added read-only `GET /cases`.
- Added database foundation for operational cases and next actions.
- Added frontend `operationsApiService.getCases()`.
- Added minimal read-only operations case DTO/types.

## Safety

- Read-only only.
- No create/update/delete/complete/comment endpoints.
- No frontend write methods.
- No Notion sync.
- No ops memory.
- No dashboard changes.
- No mind map UI changes.
- Cases are scoped by `team_id` from authenticated user context.

## QA

- Frontend production build: pass.
- Backend TypeScript compile: pass.
- `git diff --check`: pass.
- Unauthenticated `/api/v1/cases`: returns 401 and no data.
- Authenticated browser session confirmed endpoint returns cases.

## Known notes

- Global unauth error response currently returns `message: "Internal Server Error"` with 401 from the shared error handler. This is existing auth/error-response debt, not specific to `/cases`.
- Current scoping is team-level: `WHERE oc.team_id = req.user.team_id`.
- Project/member-level scoping is not included in this foundation PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Operational Cases feature enabling teams to create and manage operational cases with type and status categorization, financial impact tracking, order number assignment, and next action planning with due dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->