### PR TITLE
docs: disclose CLA requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,6 @@ All contributions should be submitted as pull requests against the `development`
 
 ## License
 
-By contributing to Worklenz, you agree that your contributions will be licensed under the [GNU Affero General Public License Version 3 (AGPLv3)](LICENSE).
+By contributing to Worklenz, you agree to sign our [Contributor License Agreement](https://cla-assistant.io/Worklenz/worklenz), which is checked automatically on every pull request. The CLA grants ceydigital solutions private limited a perpetual, worldwide, sublicensable license to your contribution, alongside the [GNU Affero General Public License Version 3 (AGPLv3)](LICENSE) under which the core project is released — you keep full ownership of your original work.
 
 Thank you again for your interest in contributing to Worklenz! We look forward to your contributions.


### PR DESCRIPTION
## Summary
- The cla-assistant bot has required a signed CLA on every PR since 2025-06-06 (confirmed via status checks on merged PRs #150 → #152), but CONTRIBUTING.md never mentioned it.
- The old text only said contributions are "licensed under AGPLv3," which understates what contributors actually agree to via the CLA — it also grants ceydigital solutions private limited a broader, sublicensable copyright/patent license.
- This brings the doc in line with what's already being enforced, so contributors know what they're signing before they hit the CLA prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require a Contributor License Agreement alongside the AGPLv3 license.
  * Clarified that contributors retain ownership while granting specified rights to the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->