### PR TITLE
fix(security): address CodeQL findings from PR #409

### DIFF
--- a/worklenz-backend/src/ee/controllers/billing-controller.ts
+++ b/worklenz-backend/src/ee/controllers/billing-controller.ts
@@ -916,13 +916,30 @@ export default class BillingController extends WorklenzControllerBase {
    */
   @HandleExceptions()
   public static async payWithCard(req: IWorkLenzRequest, res: IWorkLenzResponse): Promise<IWorkLenzResponse> {
-    const { wallet_id, card_id, order_id, amount, currency, plan } = req.body;
-    console.log("[payWithCard] Request — wallet_id:", wallet_id, "card_id:", card_id, "order_id:", order_id, "amount:", amount, "plan:", plan);
+    const { wallet_id, card_id, order_id, plan } = req.body;
+    console.log("[payWithCard] Request — wallet_id:", wallet_id, "card_id:", card_id, "order_id:", order_id, "plan:", plan);
 
-    if (!wallet_id || !card_id || !order_id || !amount) {
+    if (!wallet_id || !card_id || !order_id) {
       console.error("[payWithCard] Missing required fields");
       return res.status(400).send(new ServerResponse(false, null,
-        "wallet_id, card_id, order_id, and amount are required"));
+        "wallet_id, card_id, and order_id are required"));
+    }
+
+    // Never trust the client-supplied amount/currency. Derive the charge from
+    // server-side pricing for the requested plan and reject unsupported
+    // plans/currencies before charging or activating a subscription.
+    let charge: { tierName: string; amount: number; currency: string };
+    try {
+      charge = await this.resolveLkrPlanCharge(plan, req.body.currency);
+    } catch (err: any) {
+      console.warn("[payWithCard] Rejected — invalid plan/currency:", err?.message);
+      return res.status(400).send(new ServerResponse(false, null,
+        err?.message || "Unsupported plan or currency"));
+    }
+    const amount = charge.amount;
+    const currency = charge.currency;
+    if (req.body.amount !== undefined && Number(req.body.amount) !== amount) {
+      console.warn(`[payWithCard] Client amount ${req.body.amount} != server amount ${amount} for plan ${plan} — using server amount`);
     }
 
     const { DP_MERCHANT_ID, DP_SECRET_KEY, DP_STAGE } = process.env;
@@ -932,7 +949,7 @@ export default class BillingController extends WorklenzControllerBase {
       wallet_id: String(wallet_id),
       card_id: String(card_id),
       order_id: String(order_id),
-      currency: currency || "LKR",
+      currency,
       amount: String(amount),
     };
 
@@ -1016,6 +1033,42 @@ export default class BillingController extends WorklenzControllerBase {
       return res.status(500).send(new ServerResponse(false, null,
         error?.response?.data?.message || "Failed to process payment"));
     }
+  }
+
+  /**
+   * Resolves the authoritative monthly charge for an LKR plan from server-side
+   * pricing. Rejects unsupported plans/currencies so the client cannot dictate
+   * the amount it is billed.
+   */
+  private static async resolveLkrPlanCharge(
+    planKey: string | undefined,
+    currency: string | undefined
+  ): Promise<{ tierName: string; amount: number; currency: string }> {
+    const normalizedCurrency = (currency || "LKR").toUpperCase();
+    if (normalizedCurrency !== "LKR") {
+      throw new Error(`Unsupported currency: ${normalizedCurrency}`);
+    }
+
+    // 'startup' is the legacy UI key for the business tier.
+    const allowedPlans = ["pro", "business", "startup"];
+    if (planKey !== undefined && !allowedPlans.includes(planKey)) {
+      throw new Error(`Unsupported plan: ${planKey}`);
+    }
+    const tierName = planKey === "pro" ? "pro" : "business";
+
+    const pricingResult = await db.query(
+      `SELECT monthly_base_price
+         FROM licensing_custom_plan_pricing
+        WHERE tier_name = $1 AND currency = 'LKR' AND is_active = TRUE
+        LIMIT 1`,
+      [tierName]
+    );
+    const price = Number(pricingResult.rows[0]?.monthly_base_price);
+    if (!Number.isFinite(price) || price <= 0) {
+      throw new Error(`No active LKR pricing found for plan: ${tierName}`);
+    }
+
+    return { tierName, amount: price, currency: "LKR" };
   }
 
   private static async activateLkrSubscription(

--- a/worklenz-backend/src/ee/controllers/billing-controller.ts
+++ b/worklenz-backend/src/ee/controllers/billing-controller.ts
@@ -939,7 +939,7 @@ export default class BillingController extends WorklenzControllerBase {
     const amount = charge.amount;
     const currency = charge.currency;
     if (req.body.amount !== undefined && Number(req.body.amount) !== amount) {
-      console.warn(`[payWithCard] Client amount ${req.body.amount} != server amount ${amount} for plan ${plan} — using server amount`);
+      console.warn(`[payWithCard] Client amount ${JSON.stringify(req.body.amount)} != server amount ${amount} for plan ${JSON.stringify(plan)} — using server amount`);
     }
 
     const { DP_MERCHANT_ID, DP_SECRET_KEY, DP_STAGE } = process.env;

--- a/worklenz-backend/src/ee/controllers/billing-controller.ts
+++ b/worklenz-backend/src/ee/controllers/billing-controller.ts
@@ -11,6 +11,7 @@ import { generatePayLinkRequest, updateUsers } from "../shared/paddle-requests";
 import axios from "axios";
 
 import crypto from "crypto";
+import { isIP } from "net";
 import { log_error } from "../../shared/utils";
 import { sendEmail } from "../../shared/email";
 
@@ -1291,6 +1292,15 @@ export default class BillingController extends WorklenzControllerBase {
         ip = ip.substring(7);
       }
 
+      // Only accept well-formed IP addresses. The value originates from
+      // client-controlled headers (x-forwarded-for / x-real-ip), so reject
+      // anything that is not a valid IPv4/IPv6 address before it is used to
+      // build the outbound geolocation request URL (prevents SSRF / URL
+      // injection via a crafted header).
+      if (ip && !isIP(ip)) {
+        ip = undefined;
+      }
+
       // Skip geolocation for localhost/private IPs (development environment)
       if (!ip || ip === '127.0.0.1' || ip === '::1' || ip.startsWith('192.168.') || ip.startsWith('10.') || ip.startsWith('172.')) {
         return res.status(200).send(new ServerResponse(true, {
@@ -1302,7 +1312,7 @@ export default class BillingController extends WorklenzControllerBase {
       }
 
       // Use free IP geolocation service (ip-api.com - no API key required, 45 requests/minute)
-      const response = await axios.get(`http://ip-api.com/json/${ip}?fields=status,country,countryCode`, {
+      const response = await axios.get(`http://ip-api.com/json/${encodeURIComponent(ip)}?fields=status,country,countryCode`, {
         timeout: 3000 // 3 second timeout
       });
 

--- a/worklenz-backend/src/ee/controllers/client-portal/client-portal-auth-controller.ts
+++ b/worklenz-backend/src/ee/controllers/client-portal/client-portal-auth-controller.ts
@@ -1525,6 +1525,8 @@ export default class ClientPortalAuthController extends ClientPortalControllerBa
 
       // Normalize email to lowercase for case-insensitive comparison
       const normalizedEmail = email ? email.toLowerCase().trim() : null;
+      // CR/LF-safe copy for log statements (prevents log-forging via crafted email)
+      const emailForLog = normalizedEmail ? normalizedEmail.replace(/[\r\n]+/g, " ") : normalizedEmail;
 
       // Security: Always return the same generic message to prevent email enumeration
       const GENERIC_SUCCESS_MESSAGE =
@@ -1595,7 +1597,7 @@ export default class ClientPortalAuthController extends ClientPortalControllerBa
           // Log error internally but don't expose to client
           console.error(
             "Failed to send password reset email for linked Worklenz user:",
-            normalizedEmail,
+            emailForLog,
             error,
           );
         }
@@ -1643,7 +1645,7 @@ export default class ClientPortalAuthController extends ClientPortalControllerBa
           // Log error internally but don't expose to client
           console.error(
             "Failed to send password reset email for:",
-            normalizedEmail,
+            emailForLog,
             error,
           );
         }

--- a/worklenz-backend/src/ee/controllers/client-portal/client-portal-auth-controller.ts
+++ b/worklenz-backend/src/ee/controllers/client-portal/client-portal-auth-controller.ts
@@ -1594,7 +1594,8 @@ export default class ClientPortalAuthController extends ClientPortalControllerBa
         } catch (error) {
           // Log error internally but don't expose to client
           console.error(
-            `Failed to send password reset email for linked Worklenz user: ${normalizedEmail}`,
+            "Failed to send password reset email for linked Worklenz user:",
+            normalizedEmail,
             error,
           );
         }
@@ -1641,7 +1642,8 @@ export default class ClientPortalAuthController extends ClientPortalControllerBa
         } catch (error) {
           // Log error internally but don't expose to client
           console.error(
-            `Failed to send password reset email for: ${normalizedEmail}`,
+            "Failed to send password reset email for:",
+            normalizedEmail,
             error,
           );
         }

--- a/worklenz-backend/src/shared/url-extractor.ts
+++ b/worklenz-backend/src/shared/url-extractor.ts
@@ -3,13 +3,19 @@ import { log_error } from "./utils";
 
 const URL_REGEX = /https?:\/\/[^\s<>"{}|\\^`[\]]+/gi;
 
+// Upper bound on the input we will scan. Task descriptions / comments are far
+// smaller than this in practice; the cap keeps the single pass below from
+// being driven by an attacker-controlled length.
+const MAX_HTML_LENGTH = 100_000;
+
 // Linear-time HTML tag stripper. A regex such as /<[^>]+>/g exhibits
 // polynomial backtracking on input with many unclosed '<' characters, so we
 // scan the string once instead.
 function stripHtml(html: string): string {
   let result = "";
   let inTag = false;
-  for (let i = 0; i < html.length; i++) {
+  const len = Math.min(html.length, MAX_HTML_LENGTH);
+  for (let i = 0; i < len; i++) {
     const ch = html[i];
     if (ch === "<") {
       inTag = true;

--- a/worklenz-backend/src/shared/url-extractor.ts
+++ b/worklenz-backend/src/shared/url-extractor.ts
@@ -3,8 +3,24 @@ import { log_error } from "./utils";
 
 const URL_REGEX = /https?:\/\/[^\s<>"{}|\\^`[\]]+/gi;
 
+// Linear-time HTML tag stripper. A regex such as /<[^>]+>/g exhibits
+// polynomial backtracking on input with many unclosed '<' characters, so we
+// scan the string once instead.
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]+>/g, ' ');
+  let result = "";
+  let inTag = false;
+  for (let i = 0; i < html.length; i++) {
+    const ch = html[i];
+    if (ch === "<") {
+      inTag = true;
+    } else if (ch === ">") {
+      if (inTag) result += " ";
+      inTag = false;
+    } else if (!inTag) {
+      result += ch;
+    }
+  }
+  return result;
 }
 
 export function extractUrls(html: string): string[] {

--- a/worklenz-backend/src/shared/url-extractor.ts
+++ b/worklenz-backend/src/shared/url-extractor.ts
@@ -14,18 +14,24 @@ const MAX_HTML_LENGTH = 100_000;
 function stripHtml(html: string): string {
   let result = "";
   let inTag = false;
+  let tagStart = -1;
   const len = Math.min(html.length, MAX_HTML_LENGTH);
   for (let i = 0; i < len; i++) {
     const ch = html[i];
-    if (ch === "<") {
+    if (ch === "<" && !inTag) {
       inTag = true;
+      tagStart = i;
     } else if (ch === ">") {
       if (inTag) result += " ";
       inTag = false;
+      tagStart = -1;
     } else if (!inTag) {
       result += ch;
     }
   }
+  // Unterminated '<' (no closing '>'): keep the trailing text so URLs after it
+  // are still extracted.
+  if (inTag && tagStart !== -1) result += html.slice(tagStart, len);
   return result;
 }
 

--- a/worklenz-backend/src/shared/url-extractor.ts
+++ b/worklenz-backend/src/shared/url-extractor.ts
@@ -22,9 +22,15 @@ function stripHtml(html: string): string {
       inTag = true;
       tagStart = i;
     } else if (ch === ">") {
-      if (inTag) result += " ";
-      inTag = false;
-      tagStart = -1;
+      if (inTag) {
+        result += " ";
+        inTag = false;
+        tagStart = -1;
+      } else {
+        // Literal '>' outside a tag (e.g. "https://example.com>docs") — keep it
+        // so the URL match terminates at the right place.
+        result += ch;
+      }
     } else if (!inTag) {
       result += ch;
     }

--- a/worklenz-client-portal/src/pages/InvoiceDetailsPage.tsx
+++ b/worklenz-client-portal/src/pages/InvoiceDetailsPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/shared/antd-imports";
 import { useNavigate, useParams } from "react-router-dom";
 import clientPortalAPI from "@/services/api";
+import { stripHtml } from "@/utils/escapeHtml";
 import { InvoiceDetails } from "@/types";
 import type { UploadFile } from "antd/es/upload/interface";
 
@@ -405,7 +406,6 @@ const InvoiceDetailsPage: React.FC = () => {
   );
 };
 
-const stripHtmlTags = (value: string): string =>
-  value.replace(/<[^>]+>/g, "").trim();
+const stripHtmlTags = (value: string): string => stripHtml(value);
 
 export default InvoiceDetailsPage;

--- a/worklenz-client-portal/src/pages/ServicesPage.tsx
+++ b/worklenz-client-portal/src/pages/ServicesPage.tsx
@@ -4,6 +4,7 @@ import { AppstoreOutlined, RightOutlined } from '@/shared/antd-imports';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useGetServicesQuery } from '../store/api';
+import { stripHtml } from '@/utils/escapeHtml';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -35,10 +36,7 @@ const ServicesPage: React.FC = () => {
 
   const stripHtmlAndTruncate = (html: string, maxLength: number = 120): string => {
     if (!html) return '';
-    const text = html.replace(/<[^>]*>/g, '');
-    const textarea = document.createElement('textarea');
-    textarea.innerHTML = text;
-    const decoded = textarea.value;
+    const decoded = stripHtml(html);
     return decoded.length > maxLength ? decoded.substring(0, maxLength) + '...' : decoded;
   };
 

--- a/worklenz-client-portal/src/utils/escapeHtml.ts
+++ b/worklenz-client-portal/src/utils/escapeHtml.ts
@@ -19,3 +19,21 @@ export const escapeHtml = (value: string | undefined | null): string => {
   return div.innerHTML;
 };
 
+/**
+ * Strips every HTML tag from a string, returning plain text.
+ *
+ * Uses the browser's HTML parser rather than a one-pass regex such as
+ * `value.replace(/<[^>]+>/g, "")`, which is an incomplete sanitizer:
+ * input like `<<script>script>` would leave a live `<script>` tag behind.
+ *
+ * @param value - The value to strip (string, undefined, or null)
+ * @returns Plain text with all tags removed (empty string if value is nullish)
+ */
+export const stripHtml = (value: string | undefined | null): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  const doc = new DOMParser().parseFromString(String(value), "text/html");
+  return (doc.body.textContent || "").trim();
+};
+

--- a/worklenz-frontend/src/components/task-drawer/shared/info-tab/comments/task-comments.tsx
+++ b/worklenz-frontend/src/components/task-drawer/shared/info-tab/comments/task-comments.tsx
@@ -27,7 +27,7 @@ import { colors } from '@/styles/colors';
 import AttachmentsGrid from '../attachments/attachments-grid';
 import { TFunction } from 'i18next';
 import SingleAvatar from '@/components/common/single-avatar/single-avatar';
-import { sanitizeCommentContent } from '@/utils/sanitizeInput';
+import { sanitizeCommentContent, stripHtmlTags } from '@/utils/sanitizeInput';
 import { REACTION_CONFIGS } from '@/shared/reaction-config';
 import { toggleUpgradeModal } from '@/features/admin-center/admin-center.slice';
 import { hasBusinessFeatureAccess } from '@/ee/utils/subscription-utils';
@@ -150,7 +150,7 @@ const prepareContentForEditing = (content: string): string => {
   const withRawUrls = withoutMentionSpans.replace(/<a[^>]*href="([^"]*)"[^>]*>[^<]*<\/a>/gi, '$1');
 
   // Strip any remaining HTML tags, then trim leading/trailing whitespace
-  return withRawUrls.replace(/<[^>]*>/g, '').trim();
+  return stripHtmlTags(withRawUrls);
 };
 
 const TaskComments = ({ taskId, t, isGuest = false }: { taskId?: string; t: TFunction; isGuest?: boolean }) => {

--- a/worklenz-frontend/src/pages/reporting/projects-reports/components/projects-reports-table/table-cells/project-update-cell/project-update-cell.tsx
+++ b/worklenz-frontend/src/pages/reporting/projects-reports/components/projects-reports-table/table-cells/project-update-cell/project-update-cell.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@/shared/antd-imports';
-import { sanitizeHtml } from '@/utils/sanitizeInput';
+import { sanitizeHtml, stripHtmlTags } from '@/utils/sanitizeInput';
 
 type ProjectUpdateCellProps = {
   updates: string;
@@ -10,7 +10,7 @@ const ProjectUpdateCell = ({ updates }: ProjectUpdateCellProps) => {
   const sanitizedContent = sanitizeHtml(updates || '');
 
   // Strip HTML tags for the plain text version (for tooltip and display)
-  const plainText = sanitizedContent.replace(/<[^>]*>/g, '').trim();
+  const plainText = stripHtmlTags(sanitizedContent);
 
   return (
     <Tooltip title={plainText} placement="topLeft">

--- a/worklenz-frontend/src/utils/sanitizeInput.ts
+++ b/worklenz-frontend/src/utils/sanitizeInput.ts
@@ -23,8 +23,9 @@ export const sanitizeInput = (input: string, options?: DOMPurify.Config): string
  * Strips every HTML tag from a string, returning plain text.
  *
  * Prefer this over a one-pass regex such as `str.replace(/<[^>]*>/g, '')`,
- * which is an incomplete sanitizer: input like `<<script>script>` leaves a
- * live `<script>` tag behind. DOMPurify parses the markup and removes tags
+ * which is an incomplete sanitizer: it leaves stray angle brackets and broken
+ * markup behind (e.g. `<<script>script>` becomes `script>`) and does not cope
+ * with nested or malformed tags. DOMPurify parses the markup and removes tags
  * completely.
  *
  * @param input - The string to strip

--- a/worklenz-frontend/src/utils/sanitizeInput.ts
+++ b/worklenz-frontend/src/utils/sanitizeInput.ts
@@ -34,11 +34,16 @@ export const sanitizeInput = (input: string, options?: DOMPurify.Config): string
 export const stripHtmlTags = (input: string): string => {
   if (!input) return '';
 
-  return DOMPurify.sanitize(input, {
+  // Return a DOM fragment so we can read decoded text (`R&D`) instead of the
+  // serialized form (`R&amp;D`) that would otherwise be rendered verbatim.
+  const fragment = DOMPurify.sanitize(input, {
     ALLOWED_TAGS: [],
     ALLOWED_ATTR: [],
     KEEP_CONTENT: true,
-  }).trim();
+    RETURN_DOM_FRAGMENT: true,
+  });
+
+  return fragment.textContent?.trim() ?? '';
 };
 
 /**

--- a/worklenz-frontend/src/utils/sanitizeInput.ts
+++ b/worklenz-frontend/src/utils/sanitizeInput.ts
@@ -20,6 +20,27 @@ export const sanitizeInput = (input: string, options?: DOMPurify.Config): string
 };
 
 /**
+ * Strips every HTML tag from a string, returning plain text.
+ *
+ * Prefer this over a one-pass regex such as `str.replace(/<[^>]*>/g, '')`,
+ * which is an incomplete sanitizer: input like `<<script>script>` leaves a
+ * live `<script>` tag behind. DOMPurify parses the markup and removes tags
+ * completely.
+ *
+ * @param input - The string to strip
+ * @returns Plain text with all tags removed
+ */
+export const stripHtmlTags = (input: string): string => {
+  if (!input) return '';
+
+  return DOMPurify.sanitize(input, {
+    ALLOWED_TAGS: [],
+    ALLOWED_ATTR: [],
+    KEEP_CONTENT: true,
+  }).trim();
+};
+
+/**
  * Sanitizes a string for use in HTML contexts (allows some basic tags)
  * Enhanced configuration to prevent XSS attacks while allowing safe formatting
  *


### PR DESCRIPTION
- url-extractor: replace backtracking-prone /<[^>]+>/g tag stripper with a linear single-pass scan (polynomial ReDoS on unclosed '<').
- billing-controller checkRegion: reject non-IP values from client-controlled x-forwarded-for / x-real-ip headers and encodeURIComponent the value before building the outbound geolocation URL (SSRF / URL injection).
- client-portal-auth forgot-password: pass user email as a console.error argument instead of interpolating it into the format string.
- frontend/client-portal: strip HTML via the DOM parser / DOMPurify instead of a single-pass regex (incomplete multi-character sanitization). Adds stripHtmlTags() to sanitizeInput and stripHtml() to escapeHtml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid IP addresses during regional checks.
  * Strengthened HTML content removal across comments, project updates, invoices, and service descriptions.
  * Prevented potential performance issues when processing malformed HTML.
  * Improved password-reset error logging for client accounts.
  * Ensured card payments use validated plan pricing and supported currencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->