### PR TITLE
fix(security): address CodeQL findings on development

### DIFF
--- a/worklenz-backend/src/controllers/auth-controller.ts
+++ b/worklenz-backend/src/controllers/auth-controller.ts
@@ -26,7 +26,10 @@ export default class AuthController extends WorklenzControllerBase {
   }
 
   public static async checkPasswordStrength(req: IWorkLenzRequest, res: IWorkLenzResponse) {
-    const result = PasswordStrengthChecker.validate(req.query.password as string);
+    // Coerce to a scalar string — a repeated query param (?password=a&password=b) arrives as an array
+    const rawPassword = req.query.password;
+    const password = typeof rawPassword === "string" ? rawPassword : "";
+    const result = PasswordStrengthChecker.validate(password);
     return res.status(200).send(new ServerResponse(true, result));
   }
 

--- a/worklenz-backend/src/controllers/imports-controller.ts
+++ b/worklenz-backend/src/controllers/imports-controller.ts
@@ -9,6 +9,7 @@ import ImportsService, {
 } from "../services/imports-service";
 import safeControllerFunction from "../shared/safe-controller-function";
 import createHttpError from "http-errors";
+import { assertSafeExternalHost } from "../shared/ssrf-guard";
 import { ServerResponse } from "../models/server-response";
 import ImportIngestionService from "../services/import-ingestion-service";
 import axios from "axios";
@@ -1144,8 +1145,8 @@ export default class ImportsController {
       if (!email) throw createHttpError(400, "email is required");
       if (!domain) throw createHttpError(400, "domain is required");
 
-      // Remove protocol and trailing slashes from domain
-      const cleanDomain = domain.replace(/^https?:\/\//, "").replace(/\/$/, "");
+      // Validate the user-supplied domain and reject internal/private hosts (SSRF guard)
+      const cleanDomain = assertSafeExternalHost(domain);
       const baseUrl = `https://${cleanDomain}`;
 
       // Create Basic Auth header

--- a/worklenz-backend/src/controllers/project-comments-controller.ts
+++ b/worklenz-backend/src/controllers/project-comments-controller.ts
@@ -6,7 +6,7 @@ import db from "../config/db";
 import { ServerResponse } from "../models/server-response";
 import WorklenzControllerBase from "./worklenz-controller-base";
 import HandleExceptions from "../decorators/handle-exceptions";
-import { getColor, slugify, sanitizeCommentContent, megabytesToBytes } from "../shared/utils";
+import { escapeRegExp, getColor, slugify, sanitizeCommentContent, megabytesToBytes } from "../shared/utils";
 import { HTML_TAG_REGEXP } from "../shared/constants";
 import { IProjectCommentEmailNotification } from "../interfaces/comment-email-notification";
 import { sendProjectComment } from "../shared/email-notifications";
@@ -50,7 +50,7 @@ export default class ProjectCommentsController extends WorklenzControllerBase {
 
     const replacedContent = mentionNames.reduce(
       (content, mentionName, index) => {
-        const regex = new RegExp(`@${mentionName}`, "g");
+        const regex = new RegExp(`@${escapeRegExp(mentionName)}`, "g");
         return content.replace(regex, `{${index}}`);
       },
       messageContent

--- a/worklenz-backend/src/controllers/reporting/projects/reporting-projects-export-controller.ts
+++ b/worklenz-backend/src/controllers/reporting/projects/reporting-projects-export-controller.ts
@@ -192,11 +192,24 @@ export default class ReportingProjectsExportController extends ReportingProjects
   }
 
 
+  /**
+   * Coerces a single request-supplied value to a strict YYYY-MM-DD string, or
+   * null if it is not a scalar parseable date. Guards against type confusion
+   * (array/object params) and SQL injection via the interpolated clause below.
+   */
+  private static toStrictIsoDate(value: unknown): string | null {
+    if (typeof value !== "string" && typeof value !== "number") return null;
+    const formatted = moment(String(value)).format("YYYY-MM-DD");
+    return /^\d{4}-\d{2}-\d{2}$/.test(formatted) ? formatted : null;
+  }
+
   protected static getMinMaxDates(key: string, dateRange: string[]) {
-    if (dateRange.length === 2) {
-      const start = moment(dateRange[0]).format("YYYY-MM-DD");
-      const end = moment(dateRange[1]).format("YYYY-MM-DD");
-      return `,(SELECT '${start}'::DATE )AS start_date, (SELECT '${end}'::DATE )AS end_date`;
+    if (Array.isArray(dateRange) && dateRange.length === 2) {
+      const start = this.toStrictIsoDate(dateRange[0]);
+      const end = this.toStrictIsoDate(dateRange[1]);
+      if (start && end) {
+        return `,(SELECT '${start}'::DATE )AS start_date, (SELECT '${end}'::DATE )AS end_date`;
+      }
     }
 
     if (key === DATE_RANGES.YESTERDAY)

--- a/worklenz-backend/src/controllers/task-comments-controller.ts
+++ b/worklenz-backend/src/controllers/task-comments-controller.ts
@@ -6,7 +6,7 @@ import { ServerResponse } from "../models/server-response";
 import WorklenzControllerBase from "./worklenz-controller-base";
 import HandleExceptions from "../decorators/handle-exceptions";
 import { NotificationsService } from "../services/notifications/notifications.service";
-import { humanFileSize, log_error, megabytesToBytes, sanitizeCommentContent, sanitizePlainText } from "../shared/utils";
+import { escapeRegExp, humanFileSize, log_error, megabytesToBytes, sanitizeCommentContent, sanitizePlainText } from "../shared/utils";
 import { HTML_TAG_REGEXP, S3_URL } from "../shared/constants";
 import { getBaseUrl } from "../cron_jobs/helpers";
 import { ICommentEmailNotification } from "../interfaces/comment-email-notification";
@@ -60,7 +60,7 @@ export default class TaskCommentsController extends WorklenzControllerBase {
 
     const replacedContent = mentionNames.reduce(
       (content, mentionName, index) => {
-        const regex = new RegExp(`@${mentionName}`, "g");
+        const regex = new RegExp(`@${escapeRegExp(mentionName)}`, "g");
         return content.replace(regex, `{${index}}`);
       },
       messageContent

--- a/worklenz-backend/src/middlewares/validators/project-files-validator.ts
+++ b/worklenz-backend/src/middlewares/validators/project-files-validator.ts
@@ -4,6 +4,7 @@ import { NextFunction } from "express";
 import { IWorkLenzRequest } from "../../interfaces/worklenz-request";
 import { IWorkLenzResponse } from "../../interfaces/worklenz-response";
 import { ServerResponse } from "../../models/server-response";
+import sanitizeHtmlLib from "sanitize-html";
 import { sanitizeSVG } from "../../shared/utils";
 
 export const MAX_PROJECT_FILE_SIZE_BYTES = 100 * 1024 * 1024; // 100 MB
@@ -44,10 +45,26 @@ const sanitizeFileName = (fileName: string, extension: string): string => {
 };
 
 const sanitizeXmlContent = (content: string): string => {
-  return content
-    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
-    .replace(/on\w+\s*=\s*"[^"]*"/gi, "")
-    .replace(/on\w+\s*=\s*'[^']*'/gi, "");
+  // Regex stripping is bypassable (CodeQL: bad tag filter / incomplete
+  // sanitization). Delegate to sanitize-html: drop <script>/<style> and their
+  // contents, strip every event-handler attribute, and neutralise dangerous
+  // URL schemes, while otherwise preserving the document's tag structure.
+  return sanitizeHtmlLib(content, {
+    allowedTags: false,
+    allowedAttributes: false,
+    disallowedTagsMode: "discard",
+    exclusiveFilter: frame => frame.tag === "script" || frame.tag === "style",
+    allowedSchemes: ["http", "https", "mailto"],
+    transformTags: {
+      "*": (tagName, attribs) => {
+        const clean: Record<string, string> = {};
+        for (const key of Object.keys(attribs)) {
+          if (!/^on/i.test(key)) clean[key] = attribs[key];
+        }
+        return { tagName, attribs: clean };
+      },
+    },
+  });
 };
 
 export default function projectFilesValidator(

--- a/worklenz-backend/src/services/import-providers/csv-provider.ts
+++ b/worklenz-backend/src/services/import-providers/csv-provider.ts
@@ -2,12 +2,17 @@ import createHttpError from "http-errors";
 import { ImportProvider, ProviderResult } from "./provider-types";
 import { ImportJob, StageTaskRow } from "../imports-service";
 
+// Upper bound on CSV payload we will parse. Keeps the single-pass loop below
+// from being driven by an attacker-controlled length (CodeQL loop-bound check).
+const MAX_CSV_LENGTH = 10 * 1024 * 1024; // 10 MB
+
 function parseCsv(text: string): string[][] {
   const rows: string[][] = [];
   let current: string[] = [];
   let field = "";
   let inQuotes = false;
-  for (let i = 0; i < text.length; i++) {
+  const len = Math.min(text.length, MAX_CSV_LENGTH);
+  for (let i = 0; i < len; i++) {
     const char = text[i];
     const next = text[i + 1];
     if (char === '"') {
@@ -49,8 +54,11 @@ export default class CsvProvider implements ImportProvider {
     _job: ImportJob,
     payload?: Record<string, unknown>
   ): Promise<ProviderResult> {
-    const csvText = (payload?.csvText as string) || "";
+    const csvText = typeof payload?.csvText === "string" ? payload.csvText : "";
     if (!csvText.trim()) return { tasks: [], fields: [] };
+    if (csvText.length > MAX_CSV_LENGTH) {
+      throw createHttpError(400, "The CSV file is too large. Please upload a file smaller than 10 MB.");
+    }
 
     // Reject binary content (PDF, images, etc.) — check for non-text byte sequences
     const sample = csvText.slice(0, 512);

--- a/worklenz-backend/src/services/import-providers/jira-provider.ts
+++ b/worklenz-backend/src/services/import-providers/jira-provider.ts
@@ -7,6 +7,7 @@ import {
 } from "../imports-service";
 import { getWithRetries } from "./http-utils";
 import db from "../../config/db";
+import { assertSafeExternalHost } from "../../shared/ssrf-guard";
 
 interface JiraIssue {
   id: string;
@@ -234,7 +235,10 @@ export default class JiraProvider implements ImportProvider {
       );
     }
 
-    return { token, email, domain, projectKey, projectName };
+    // Reject internal/private hosts before any outbound request is made (SSRF guard)
+    const safeDomain = assertSafeExternalHost(domain as string);
+
+    return { token, email, domain: safeDomain, projectKey, projectName };
   }
 
   private buildAuthHeader(email: string, token: string): string {

--- a/worklenz-backend/src/services/token-service.ts
+++ b/worklenz-backend/src/services/token-service.ts
@@ -462,7 +462,7 @@ class TokenService {
         return null; // Password doesn't match
       }
     } catch (error) {
-      console.error(`[Client Auth] Error during authentication for email: ${email}`, error);
+      console.error("[Client Auth] Error during authentication for email:", email, error);
       return null;
     }
   }

--- a/worklenz-backend/src/shared/email.ts
+++ b/worklenz-backend/src/shared/email.ts
@@ -1,6 +1,8 @@
 import { SendEmailCommand, SESClient } from "@aws-sdk/client-ses";
 import { Validator } from "jsonschema";
 import { QueryResult } from "pg";
+import lodash from "lodash";
+import sanitizeHtmlLib from "sanitize-html";
 import { log_error, isValidateEmail } from "./utils";
 import emailRequestSchema from "../json_schemas/email-request-schema";
 import db from "../config/db";
@@ -226,11 +228,12 @@ export async function sendEmailEnhanced(email: IEmail): Promise<IEmailResult> {
 
     const charset = "UTF-8";
     
-    // Generate plain text version by stripping HTML tags
-    const plainText = options.html
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<[^>]+>/g, ' ')
+    // Generate plain text version by stripping HTML tags. Use sanitize-html
+    // (drops <script>/<style> and their contents reliably) then decode entities
+    // so the plaintext body reads naturally.
+    const plainText = lodash.unescape(
+      sanitizeHtmlLib(options.html, { allowedTags: [], allowedAttributes: {} })
+    )
       .replace(/\s+/g, ' ')
       .trim();
     

--- a/worklenz-backend/src/shared/password-strength-check.ts
+++ b/worklenz-backend/src/shared/password-strength-check.ts
@@ -30,7 +30,7 @@ export class PasswordStrengthChecker {
   private static readonly defaultAllowedSymbols = "!\"#\$%&'\(\)\*\+,-\./:;<=>\?@\[\\\\\\]\^_`\{|\}~";
 
   public static validate(password: string, options = this.defaultOptions, allowedSymbols = this.defaultAllowedSymbols): IPasswordValidityResult {
-    const passwordCopy = password || "";
+    const passwordCopy = typeof password === "string" ? password : "";
 
     options[0].minDiversity = 0;
     options[0].minLength = 0;

--- a/worklenz-backend/src/shared/ssrf-guard.ts
+++ b/worklenz-backend/src/shared/ssrf-guard.ts
@@ -1,0 +1,91 @@
+import { isIP } from "net";
+import createHttpError from "http-errors";
+
+/**
+ * Guards against Server-Side Request Forgery (SSRF) when an outbound HTTP
+ * request targets a host that originates from user input (e.g. a self-hosted
+ * JIRA domain supplied during an import).
+ *
+ * It rejects hostnames that point at the local machine or private/internal
+ * network ranges, so a caller cannot coerce the server into probing
+ * `localhost`, cloud metadata endpoints (169.254.169.254) or RFC1918 hosts.
+ */
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+]);
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(Number);
+  if (parts.length !== 4 || parts.some(p => Number.isNaN(p) || p < 0 || p > 255)) return true;
+  const [a, b] = parts;
+  if (a === 10) return true;                       // 10.0.0.0/8
+  if (a === 127) return true;                      // loopback
+  if (a === 0) return true;                        // "this" network
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true;         // 192.168.0.0/16
+  if (a === 169 && b === 254) return true;         // link-local / cloud metadata
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a >= 224) return true;                       // multicast / reserved
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "::1" || normalized === "::") return true;
+  if (normalized.startsWith("fe80") || normalized.startsWith("fc") || normalized.startsWith("fd")) return true;
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d)
+  const mapped = normalized.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPrivateIPv4(mapped[1]);
+  return false;
+}
+
+/**
+ * Validates and normalizes a user-supplied host (optionally with scheme / path)
+ * for use as an outbound request target. Returns the bare hostname (no scheme,
+ * no trailing slash). Throws a 400 HttpError when the value is malformed or
+ * resolves to a disallowed address.
+ */
+export function assertSafeExternalHost(rawInput: string | undefined | null): string {
+  const value = (rawInput ?? "").trim();
+  if (!value) throw createHttpError(400, "A valid domain is required");
+
+  let url: URL;
+  try {
+    // Accept "example.com", "https://example.com/x" and "example.com/x" alike.
+    url = new URL(value.includes("://") ? value : `https://${value}`);
+  } catch {
+    throw createHttpError(400, "Invalid domain");
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw createHttpError(400, "Only http(s) domains are supported");
+  }
+  if (url.username || url.password) {
+    throw createHttpError(400, "Domain must not contain credentials");
+  }
+  const host = url.hostname;
+
+  const lowerHost = host.toLowerCase();
+
+  if (BLOCKED_HOSTNAMES.has(lowerHost) || lowerHost.endsWith(".localhost") || lowerHost.endsWith(".local") || lowerHost.endsWith(".internal")) {
+    throw createHttpError(400, "The provided domain is not allowed");
+  }
+
+  // URL parsing keeps IPv6 literals bracketed (e.g. "[::1]") — strip for isIP().
+  const bareHost = host.replace(/^\[|\]$/g, "");
+  const ipVersion = isIP(bareHost);
+  if (ipVersion === 4 && isPrivateIPv4(bareHost)) {
+    throw createHttpError(400, "The provided domain is not allowed");
+  }
+  if (ipVersion === 6 && isPrivateIPv6(bareHost)) {
+    throw createHttpError(400, "The provided domain is not allowed");
+  }
+  if (ipVersion === 0 && /:/.test(bareHost)) {
+    // Malformed IPv6-looking host that isIP() rejects — refuse rather than guess.
+    throw createHttpError(400, "Invalid domain");
+  }
+
+  return host;
+}

--- a/worklenz-backend/src/shared/url-extractor.ts
+++ b/worklenz-backend/src/shared/url-extractor.ts
@@ -41,11 +41,22 @@ function stripHtml(html: string): string {
   return result;
 }
 
+// Trailing punctuation that is almost always sentence structure rather than
+// part of the URL. Trimmed with a linear scan — an anchored regex like
+// /[.,;:!?)]+$/ backtracks polynomially on a URL ending in many such chars.
+const TRAILING_PUNCTUATION = new Set([".", ",", ";", ":", "!", "?", ")"]);
+
+function trimTrailingPunctuation(url: string): string {
+  let end = url.length;
+  while (end > 0 && TRAILING_PUNCTUATION.has(url[end - 1])) end--;
+  return url.slice(0, end);
+}
+
 export function extractUrls(html: string): string[] {
   const text = stripHtml(html);
   const matches = text.match(URL_REGEX);
   if (!matches) return [];
-  return [...new Set(matches.map(url => url.replace(/[.,;:!?)]+$/, '')))];
+  return [...new Set(matches.map(trimTrailingPunctuation))];
 }
 
 export async function syncTaskDescriptionLinks(

--- a/worklenz-backend/src/shared/utils.ts
+++ b/worklenz-backend/src/shared/utils.ts
@@ -340,6 +340,15 @@ export function unescape(value: string) {
   return lodash.unescape(value);
 }
 
+/**
+ * Escapes characters that carry special meaning inside a regular expression so a
+ * user-provided string can be embedded in a `RegExp` literal safely (prevents
+ * regex-injection / ReDoS via crafted input).
+ */
+export function escapeRegExp(value: string): string {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export function isUnicode(value: string) {
   for (let i = 0, n = value.length; i < n; i++) {
     if (value.charCodeAt(i) > 255) return true;

--- a/worklenz-backend/src/shared/validation-helpers.ts
+++ b/worklenz-backend/src/shared/validation-helpers.ts
@@ -3,6 +3,8 @@
  * injection attacks and ensure data integrity.
  */
 
+import sanitizeHtmlLib from "sanitize-html";
+
 /**
  * UUID v4 validator
  * Validates that a string is a valid UUID v4 format
@@ -85,12 +87,22 @@ export const sanitizeHtml = (html: string): string => {
     return '';
   }
   
-  // Basic HTML sanitization - remove script tags and dangerous attributes
-  return html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '') // Remove script tags
-    .replace(/on\w+\s*=\s*["'][^"']*["']/gi, '') // Remove event handlers
-    .replace(/javascript:/gi, '') // Remove javascript: protocol
-    .replace(/data:text\/html/gi, ''); // Remove data URIs with HTML
+  // Delegate to the well-vetted sanitize-html library. Hand-rolled regex
+  // stripping is bypassable (nested tags, mixed schemes) — CodeQL flags it as
+  // incomplete multi-character sanitization / bad tag filter.
+  return sanitizeHtmlLib(html, {
+    allowedTags: [
+      'p', 'br', 'b', 'i', 'em', 'strong', 'u', 's', 'a', 'ul', 'ol', 'li',
+      'blockquote', 'code', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span', 'div',
+    ],
+    allowedAttributes: {
+      a: ['href', 'target', 'rel'],
+      span: ['class'],
+      div: ['class'],
+    },
+    allowedSchemes: ['http', 'https', 'mailto'],
+    disallowedTagsMode: 'discard',
+  });
 };
 
 /**

--- a/worklenz-frontend/src/components/navbar/notifications/notifications-drawer/notification/notfication-drawer.tsx
+++ b/worklenz-frontend/src/components/navbar/notifications/notifications-drawer/notification/notfication-drawer.tsx
@@ -46,8 +46,7 @@ import { openUpgradeModal } from '@/features/admin-center/admin-center.slice';
 import { APPSUMO_DRAWER_IMAGE_URL } from '@/config/appsumo-promo.config';
 import { useMixpanelTracking } from '@/hooks/useMixpanelTracking';
 import { MixpanelBillingEvents } from '@/types/mixpanel-events.types';
-
-const HTML_TAG_REGEXP = /<[^>]*>/g;
+import { stripHtmlTags } from '@/utils/sanitizeInput';
 
 const NotificationDrawer = () => {
   const { token } = theme.useToken();
@@ -83,7 +82,7 @@ const NotificationDrawer = () => {
     if (Notification.permission === 'granted' && showBrowserPush) {
       const img = 'https://worklenz.com/assets/icons/icon-128x128.png';
       const notification = new Notification(title, {
-        body: message.replace(HTML_TAG_REGEXP, ''),
+        body: stripHtmlTags(message),
         icon: img,
         badge: img,
       });

--- a/worklenz-frontend/src/components/task-drawer/shared/info-tab/comments/task-view-comment-edit.tsx
+++ b/worklenz-frontend/src/components/task-drawer/shared/info-tab/comments/task-view-comment-edit.tsx
@@ -8,6 +8,7 @@ import { themeWiseColor } from '@/utils/themeWiseColor';
 import { colors } from '@/styles/colors';
 import { useSocket } from '@/socket/socketContext';
 import { SocketEvents } from '@/shared/socket-events';
+import { stripHtmlTags } from '@/utils/sanitizeInput';
 
 interface TaskViewCommentEditProps {
   commentData: ITaskCommentViewModel;
@@ -37,8 +38,8 @@ const prepareContentForEditing = (content: string): string => {
   //    the original URL they typed, not the display label
   const withRawUrls = withoutMentionSpans.replace(/<a[^>]*href="([^"]*)"[^>]*>[^<]*<\/a>/gi, '$1');
 
-  // 3. Strip any remaining HTML tags
-  return withRawUrls.replace(/<[^>]*>/g, '');
+  // 3. Strip any remaining HTML tags (DOMPurify-based; a one-pass regex is bypassable)
+  return stripHtmlTags(withRawUrls);
 };
 
 const TaskViewCommentEdit = ({ commentData, onUpdated }: TaskViewCommentEditProps) => {

--- a/worklenz-frontend/src/config/env.ts
+++ b/worklenz-frontend/src/config/env.ts
@@ -94,11 +94,11 @@ export const getClientPortalBaseUrl = (): string => {
   // For production/UST, derive from current hostname
   // If on app.worklenz.com, client portal might be on client.worklenz.com
   // Or use the same hostname with different subdomain
-  if (hostname.includes('worklenz.com')) {
-    // Replace 'app' with 'client' or use the same hostname
-    const clientHostname = hostname
-      .replace('app.', 'client.')
-      .replace('worklenz.com', 'worklenz.com');
+  if (hostname === 'worklenz.com' || hostname.endsWith('.worklenz.com')) {
+    // Swap the leading 'app.' subdomain for 'client.', otherwise keep the host as-is
+    const clientHostname = hostname.startsWith('app.')
+      ? `client.${hostname.slice('app.'.length)}`
+      : hostname;
     return `${protocol}//${clientHostname}`;
   }
 

--- a/worklenz-frontend/src/features/project/project-drawer.slice.ts
+++ b/worklenz-frontend/src/features/project/project-drawer.slice.ts
@@ -41,7 +41,7 @@ export const fetchProjectData = createAsyncThunk(
       return response.body;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to fetch project';
-      console.error(`Error fetching project data for ID ${projectId}:`, error);
+      console.error('Error fetching project data for ID', projectId, error);
       return rejectWithValue(errorMessage);
     }
   }

--- a/worklenz-frontend/src/utils/html-entities.ts
+++ b/worklenz-frontend/src/utils/html-entities.ts
@@ -14,14 +14,10 @@ export function decodeHtmlEntities(text: string | undefined): string {
     return '';
   }
 
-  if (typeof document === 'undefined') {
-    return decodeHtmlEntitiesFallback(text);
-  }
-
-  // Create a temporary element to decode HTML entities
-  const textarea = document.createElement('textarea');
-  textarea.innerHTML = text;
-  return textarea.value;
+  // Decode without assigning untrusted input to `innerHTML` (avoids the
+  // xss-through-dom sink). The backend only emits a small, known set of named
+  // entities plus numeric character references, both handled below.
+  return decodeHtmlEntitiesFallback(text);
 }
 
 /**
@@ -62,10 +58,29 @@ export function decodeHtmlEntitiesFallback(text: string): string {
   }
 
   let decoded = text;
+
+  // Numeric character references: &#123; and &#x1F600;
+  decoded = decoded
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => safeFromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => safeFromCodePoint(parseInt(dec, 10)));
+
   Object.entries(HTML_ENTITY_MAP).forEach(([entity, char]) => {
+    if (entity === '&amp;') return; // handled last, see below
     const regex = new RegExp(entity.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
     decoded = decoded.replace(regex, char);
   });
 
+  // &amp; must be decoded last so "&amp;lt;" does not collapse to "<"
+  decoded = decoded.replace(/&amp;/g, '&');
+
   return decoded;
+}
+
+function safeFromCodePoint(code: number): string {
+  if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return '';
+  try {
+    return String.fromCodePoint(code);
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
Focused pass over the **real** (non-noise) CodeQL alerts open on `development`. Backend `tsc` and frontend `vite build` both pass.

## Fixed

| CodeQL rule | Fix |
|---|---|
| `js/regex-injection` (×2) | new `escapeRegExp()` helper; escape user mention names before `new RegExp` (task/project comment controllers) |
| `js/request-forgery` – SSRF (×2, critical) | new `shared/ssrf-guard.ts` – rejects `localhost` / RFC1918 / link-local / `169.254.169.254` / IPv6 loopback+ULA. Applied at JIRA credential validation and inside `jira-provider` |
| `js/type-confusion-through-parameter-tampering` (×2, critical) | coerce array/scalar query params to strings (password-strength check, reporting export); strict `YYYY-MM-DD` validation before interpolating dates into SQL |
| `js/loop-bound-injection` | 10 MB cap on CSV parse input |
| `js/polynomial-redos` | linear trailing-punctuation trim instead of anchored `/[.,;:!?)]+$/` in URL extractor |
| `js/incomplete-multi-character-sanitization`, `js/bad-tag-filter`, `js/incomplete-url-scheme-check` | replace hand-rolled regex HTML stripping with `sanitize-html` (backend `validation-helpers`, email plaintext, project-files XML validator) and DOMPurify `stripHtmlTags` (frontend notification body, comment edit) |
| `js/tainted-format-string` (×2) | pass interpolated values as separate `console.*` args |
| `js/xss-through-dom` | decode HTML entities without assigning untrusted input to `innerHTML`; add numeric char-ref handling + correct `&amp;` ordering |
| `js/incomplete-url-substring-sanitization` + `js/identity-replacement` | proper `endsWith('.worklenz.com')` host check; fix no-op `.replace('worklenz.com', 'worklenz.com')` |

## Intentionally out of scope

- **`js/sql-injection` @ `config/db.ts:26`** – the shared `pool.query()` wrapper; flagged because ~28 call sites concatenate SQL. Needs a per-caller audit (one done here: reporting date-range).
- **`js/missing-token-validation` @ `app.ts:55` (CSRF)** – needs a repo-wide CSRF-token strategy.
- **`js/insufficient-password-hash` @ `token-service.ts:350`** – legacy SHA-256 *verification* path with lazy bcrypt migration; removing it locks out un-migrated client-portal users.
- **`js/missing-rate-limiting` (~40)** and **`src/public/tinymce/**`** – low-signal / vendored bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)