### PR TITLE
chore(release): bump version to 3.0.0

### DIFF
--- a/worklenz-backend/package-lock.json
+++ b/worklenz-backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worklenz-backend",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worklenz-backend",
-      "version": "2.2.3",
+      "version": "3.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.952.0",
         "@aws-sdk/client-ses": "^3.378.0",

--- a/worklenz-backend/package.json
+++ b/worklenz-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worklenz-backend",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "private": true,
   "engines": {
     "npm": ">=8.11.0",

--- a/worklenz-backend/src/docs/openapi.yaml
+++ b/worklenz-backend/src/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Worklenz API
-  version: 2.2.3
+  version: 3.0.0
   description: |
     Worklenz project management platform API documentation.
 

--- a/worklenz-client-portal/package-lock.json
+++ b/worklenz-client-portal/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worklenz-client-portal",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worklenz-client-portal",
-      "version": "2.2.3",
+      "version": "3.0.0",
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@ant-design/v5-patch-for-react-19": "^1.0.3",

--- a/worklenz-client-portal/package.json
+++ b/worklenz-client-portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worklenz-client-portal",
   "private": true,
-  "version": "2.2.3",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/worklenz-frontend/package-lock.json
+++ b/worklenz-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "worklenz",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "worklenz",
-      "version": "2.2.3",
+      "version": "3.0.0",
       "dependencies": {
         "@ant-design/colors": "^7.1.0",
         "@ant-design/compatible": "^5.1.4",

--- a/worklenz-frontend/package.json
+++ b/worklenz-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worklenz",
-  "version": "2.2.3",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "start": "vite dev",


### PR DESCRIPTION
First release of the **open-core edition**. The open-source and Enterprise editions now share a version scheme — the Enterprise line is at 3.x, and this bump aligns the open-source repo (previously on 2.x, last tag `v2.1.7`, `package.json` at `2.2.3`) with it going forward. `v3.0.0` is the deliberate convergence point; subsequent shared releases continue from `3.x`.

## Changes
- `worklenz-frontend`, `worklenz-backend`, `worklenz-client-portal` — `version` in `package.json` + `package-lock.json` → `3.0.0`
- `worklenz-backend/src/docs/openapi.yaml` — API `version` → `3.0.0`

## After merge
1. `git tag v3.0.0` on `main` and push, or publish a GitHub Release with tag `v3.0.0`
2. The `Publish Docker Images` workflow fires on `release: published` and tags `ghcr.io/worklenz/worklenz_{frontend,backend}` as `3.0.0`, `3.0`, `3`, `latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 3.0.0 across the backend, frontend, client portal, and API documentation.
  * Synchronized the published API specification with the new release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->