### PR TITLE
fix(backend): sync package-lock with package.json (unblocks Docker build)

### DIFF
--- a/worklenz-backend/package-lock.json
+++ b/worklenz-backend/package-lock.json
@@ -28,7 +28,7 @@
         "cron": "^2.4.0",
         "crypto-js": "^4.1.1",
         "csrf-sync": "^4.2.1",
-        "date-holidays": "^3.24.4",
+        "date-holidays": "^3.34.1",
         "debug": "^4.3.4",
         "dotenv": "^16.3.1",
         "exceljs": "^4.3.0",
@@ -8231,14 +8231,14 @@
       }
     },
     "node_modules/date-holidays": {
-      "version": "3.26.5",
-      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.26.5.tgz",
-      "integrity": "sha512-I/nGVQAxBmLFxjwE48vWTOlZa7nKucQifHJHbkfveCco0hwE+3GvvAPYMw4iXBldvDqaruujV5AvrbOjq9UNUg==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.36.0.tgz",
+      "integrity": "sha512-uKcRwVgaIC5jEbm2Z4LQzXmTDulWcO+6kQie3GLoAiS1sYfpWmq1qrlrDHmo2BXGyIxT5o7IO0Z/jVQUZgJsCg==",
       "license": "(ISC AND CC-BY-3.0)",
       "dependencies": {
         "date-holidays-parser": "^3.4.7",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
+        "js-yaml": "^5.3.0",
+        "lodash": "^4.18.1",
         "prepin": "^1.0.3"
       },
       "bin": {
@@ -8265,6 +8265,28 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-holidays/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/dayjs": {


### PR DESCRIPTION
The `Publish Docker Images` workflow is failing on the backend image because `worklenz-backend/package-lock.json` is out of sync with `package.json`:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Invalid: lock file's date-holidays@3.26.5 does not satisfy date-holidays@3.36.0
npm error Missing: js-yaml@5.4.1 from lock file
```

The open-core sync bumped `date-holidays` to `^3.34.1` in `package.json` but left the lock at `3.26.5`.

Regenerated with `npm install --package-lock-only`:
- `date-holidays` 3.26.5 → 3.36.0
- add `js-yaml` 5.4.1 (transitive dep of date-holidays)

`npm ci --dry-run` passes after this. Frontend and client-portal locks are already in sync.

## After merge
Re-run the failed `Publish Docker Images` run for `v3.0.0`, or move the `v3.0.0` tag to include this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)